### PR TITLE
Fix missing label in GLL conversion by outputting delta directly from codec

### DIFF
--- a/codecs/GLL.js
+++ b/codecs/GLL.js
@@ -74,17 +74,24 @@ module.exports = new Codec('GLL', function(multiplexer, input) {
 	var ts 	 = this.timestamp(time);
   var self = this;
 
-	// Position
-  multiplexer
-    .self()
-    .group('navigation')
-    .set('position', {
-      source: this.source(),
-      timestamp: ts,
-      longitude: self.coordinate(values[2], values[3]),
-      latitude: self.coordinate(values[0], values[1])
-    })
-  ;
+  multiplexer.self();
+
+  multiplexer.add({
+    "updates": [{
+      "source": this.source(),
+      "timestamp": ts,
+      "values": [{
+        "path": "navigation.position",
+        "value": {
+          longitude: self.coordinate(values[2], values[3]),
+          latitude: self.coordinate(values[0], values[1])
+        }
+      }]
+    }],
+    "context": multiplexer._context
+  });
+  return true;
+
 
 	return true;
 });

--- a/test/GLL.js
+++ b/test/GLL.js
@@ -1,0 +1,22 @@
+var chai = require("chai");
+chai.Should();
+chai.use(require('chai-things'));
+
+chai.use(require('signalk-schema').chaiModule);
+
+
+var nmeaLine = "$GPGLL,5958.613,N,02325.928,E,121022,A,D*40";
+
+describe('GLL', function() {
+  it('converts ok', function(done) {
+    parser = new(require('../lib/').Parser)();
+    parser.on('delta', function(delta) {
+      delta.updates[0].values[0].path.should.equal('navigation.position');
+      delta.updates[0].values[0].value.latitude.should.be.closeTo(59.9768833, 0.000005);
+      delta.updates[0].values[0].value.longitude.should.be.closeTo(23.432133, 0.000005);
+      delta.should.be.validSignalKDelta;
+      done();
+    });
+    parser.write(nmeaLine);
+  })
+});


### PR DESCRIPTION
GLL conversion output was not valid Signal K because of the missing label property, probably due to the fact position value is an object.