### PR TITLE
Included provision for proprietary sentences

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,7 @@ Parser.prototype._lineData = function(sentence) {
 	var values 	= raw.split(',');
 
 	var data = { 
-	if (values[0][0]=="P"){
+	if(values[0][0]=="P"){
 		instrument: values[0].slice(0, 4),
 		type: values[0].slice(-3),
 		values: []

--- a/lib/index.js
+++ b/lib/index.js
@@ -95,9 +95,16 @@ Parser.prototype._lineData = function(sentence) {
 	var values 	= raw.split(',');
 
 	var data = { 
-    instrument: values[0].slice(0, 2), 
-    type: values[0].slice(-3), 
-    values: [] 
+	if (values[0][0]=="P"){
+		instrument: values[0].slice(0, 4),
+		type: values[0].slice(-3),
+		values: []
+	}
+	else {
+		instrument: values[0].slice(0, 2), 
+		type: values[0].slice(-3), 
+		values: []
+	}
   };
 
 	for(var i = 1; i < values.length; i++) {


### PR DESCRIPTION
The thought is that standard sentences will keep the 2 char talker id as ("instrument:"), whereas any proprietary sentences will keep the full 4 char talker id, including "P". This can later be used to distinguish proprietary sentences with the same "type:"

	modified:   lib/index.js