### PR TITLE
Added provision for proprietary sentences

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,11 +94,22 @@ Parser.prototype._lineData = function(sentence) {
 	var raw 	  = split[0].slice(1);
 	var values 	= raw.split(',');
 
-	var data = { 
-    instrument: values[0].slice(0, 2), 
-    type: values[0].slice(-3), 
-    values: [] 
-  };
+	if(values[0][0]=="P"){
+		var data = { 
+			instrument: values[0].slice(0, 4),
+			type: values[0].slice(-3),
+			values: []
+		};
+	}
+
+	else {
+		var data = { 
+			instrument: values[0].slice(0, 2), 
+			type: values[0].slice(-3), 
+			values: []
+		};
+	}
+	
 
 	for(var i = 1; i < values.length; i++) {
 		data.values.push(values[i]);


### PR DESCRIPTION
The proprietary sentences will keep the 4 character talker id as "instrument", including "P". This can later be used to distinguish between different protocols with the same "type"