### PR TITLE
Multiline ais

### DIFF
--- a/codecs/VDM.js
+++ b/codecs/VDM.js
@@ -1,10 +1,10 @@
 /*
  * Copyright 2015 Fabian Tollenaar <fabian@starting-point.nl>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -20,11 +20,20 @@
 var Codec   = require('../lib/NMEA0183');
 var Decoder = require ("ggencoder").AisDecode;
 
+/*
+A QUICK HACK THAT WILL NOT WORK WITH MULTIPLE
+AIS NMEA STREAMS. Implements ggencoder session
+as a global singleton. Proper implementation would be
+a per stream constructer NMEA0183 encoder that would be able
+to keep a coherent internal parsing state.
+*/
+var session = {};
+
 module.exports = new Codec('VDM', function(multiplexer, input, line) {
-  var data = new Decoder(line);
+  var data = new Decoder(line, session);
 
   if(!data.valid) {
-    return this.reportError(this.errors.VOID, "Not parsing sentence for it isn't valid."); 
+    return this.reportError(this.errors.VOID, "Not parsing sentence for it isn't valid.");
   }
 
   // Set MRN with MMSI

--- a/codecs/VDM.js
+++ b/codecs/VDM.js
@@ -12,13 +12,13 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 
 "use strict";
 
-var Codec   = require('../lib/NMEA0183');
-var Decoder = require ("ggencoder").AisDecode;
+var Codec = require('../lib/NMEA0183');
+var Decoder = require("ggencoder").AisDecode;
 
 /*
 A QUICK HACK THAT WILL NOT WORK WITH MULTIPLE
@@ -32,40 +32,67 @@ var session = {};
 module.exports = new Codec('VDM', function(multiplexer, input, line) {
   var data = new Decoder(line, session);
 
-  if(!data.valid) {
+  if (!data.valid) {
     return this.reportError(this.errors.VOID, "Not parsing sentence for it isn't valid.");
   }
 
-  // Set MRN with MMSI
-  data.mmsi = 'urn:mrn:imo:mmsi:' + data.mmsi;
-  // MMSI
-  multiplexer.vessel(data.mmsi).set('mmsi', data.mmsi);
 
-  // Position
-  multiplexer
-    .vessel(data.mmsi)
-    .group('navigation')
-    .set('position', {
-      source: this.source(input.instrument),
-      timestamp: this.timestamp(),
-      longitude: data.lon,
-      latitude: data.lat
+  var values = [];
+  if (data.mmsi) {
+    values.push({
+      path: "",
+      value: {
+        mmsi: data.mmsi
+      }
     })
-  ;
+  }
+  if (data.shipname) {
+    values.push({
+      path: "",
+      value: {
+        name: data.shipname
+      }
+    })
+  }
+  if (typeof data.sog != 'undefined') {
+    values.push({
+      path: "navigation.speedOverGround",
+      value: this.transform(data.sog, 'knots', 'ms')
+    })
+  }
+  if (typeof data.cog != 'undefined') {
+    values.push({
+      path: "navigation.courseOverGroundTrue",
+      value: this.transform(data.cog, 'deg', 'rad')
+    })
+  }
+  if (typeof data.hdg != 'undefined') {
+    values.push({
+      path: "navigation.headingTrue",
+      value: this.transform(data.hdg, 'deg', 'rad')
+    })
+  }
+  if (data.lon && data.lat) {
+    values.push({
+      path: "navigation.position",
+      value: {
+        longitude: data.lon,
+        latitude: data.lat
+      }
+    })
+  }
 
-  // Other values
-  multiplexer
-    .vessel(data.mmsi)
-    .group('navigation')
-    .timestamp(this.timestamp())
-    .source(this.source(input.instrument))
-    .values([
-      { path: "speedOverGround", value: this.transform(data.sog, 'knots', 'ms') },
-      { path: "courseOverGround", value: this.transform(data.cog, 'deg', 'rad') },
-      { path: "state", value: data.GetNavStatus() },
-      { path: "headingTrue", value: this.transform(data.hdg, 'deg', 'rad') }
-    ])
-  ;
+  if (values.length > 0) {
+    multiplexer.self();
+    multiplexer.add({
+      "updates": [{
+        "source": this.source(input.instrument),
+        "timestamp": this.timestamp(),
+        "values": values
+      }],
+      "context": 'vessels.urn:mrn:imo:mmsi:' + data.mmsi
+    });
+  }
 
   return true;
 });

--- a/test/VDM.js
+++ b/test/VDM.js
@@ -11,22 +11,46 @@ var nmeaLines = [
 ];
 
 describe('VDM', function() {
-  it('converts ok', function(done) {
-    parser = new(require('../lib/').Parser)({
+  it(' multiline converts ok', function(done) {
+    var parser = new(require('../lib/').Parser)({
       selfId: 'urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d'
     });
     parser.on('delta', function(delta) {
-      console.log(JSON.stringify(delta))
-      // asserts for delta contents go here
-
       // validate schema conformance
-      // var full = signalkSchema.deltaToFull(delta);
-      // signalkSchema.fillIdentity(full);
-      // full.should.be.validSignalK;
-      // done();
+      var full = signalkSchema.deltaToFull(delta);
+      signalkSchema.fillIdentity(full);
+      full.should.be.validSignalK;
+
+      full.vessels['urn:mrn:imo:mmsi:246326000'].should.have.property('mmsi', '246326000');
+      full.vessels['urn:mrn:imo:mmsi:246326000'].should.have.property('name', 'LUTGERDINA');
+      done();
     });
     parser.write(nmeaLines[0]);
     parser.write(nmeaLines[1]);
   })
+
+  it(' single line converts ok', function(done) {
+    var parser = new(require('../lib/').Parser)({
+      selfId: 'urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d'
+    });
+    parser.on('delta', function(delta) {
+      // validate schema conformance
+      var full = signalkSchema.deltaToFull(delta);
+      signalkSchema.fillIdentity(full);
+      full.should.be.validSignalK;
+
+      delta.updates[0].values.length.should.equal(5);
+
+      full.vessels['urn:mrn:imo:mmsi:232002939'].should.have.property('mmsi', '232002939');
+      full.vessels['urn:mrn:imo:mmsi:232002939'].navigation.courseOverGroundTrue.should.have.property('value', 6.021385919380437);
+      full.vessels['urn:mrn:imo:mmsi:232002939'].navigation.speedOverGround.should.have.property('value', 0);
+      full.vessels['urn:mrn:imo:mmsi:232002939'].navigation.headingTrue.should.have.property('value', 0.08726646259971647);
+      full.vessels['urn:mrn:imo:mmsi:232002939'].navigation.position.should.have.property('latitude', 50.806205);
+      full.vessels['urn:mrn:imo:mmsi:232002939'].navigation.position.should.have.property('longitude', -1.10399);
+      done();
+    });
+    parser.write("!AIVDM,1,1,,B,13M@ENw000OrtT<M4U2uNP;20<2<,0*39\n");
+  })
+
 
 });

--- a/test/VDM.js
+++ b/test/VDM.js
@@ -1,0 +1,32 @@
+var chai = require("chai");
+chai.Should();
+chai.use(require('chai-things'));
+var signalkSchema = require('signalk-schema');
+
+
+
+var nmeaLines = [
+  "!AIVDM,2,1,0,A,53brRt4000010SG;700iE@LE8@Tp4000000000153P615t0Ht0SCkjH4jC1C,0*1E\n",
+  "!AIVDM,2,2,0,A,`0000000001,2*75\n"
+];
+
+describe('VDM', function() {
+  it('converts ok', function(done) {
+    parser = new(require('../lib/').Parser)({
+      selfId: 'urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d'
+    });
+    parser.on('delta', function(delta) {
+      console.log(JSON.stringify(delta))
+      // asserts for delta contents go here
+
+      // validate schema conformance
+      // var full = signalkSchema.deltaToFull(delta);
+      // signalkSchema.fillIdentity(full);
+      // full.should.be.validSignalK;
+      // done();
+    });
+    parser.write(nmeaLines[0]);
+    parser.write(nmeaLines[1]);
+  })
+
+});


### PR DESCRIPTION
Add support for multiline AIS messages.

Improves AIS message handling a bit, so that it checks for existence of individual fields and creates delta accordingly.

The session handling is naive and **will not work for multiple ais streams** because of a shared singleton. The parser needs more changes to support a per parser instance session context.