### PR TITLE
Support for Seatalk through $STALK sentence

### DIFF
--- a/codecs/STALK.js
+++ b/codecs/STALK.js
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2016 Joachim Bakke
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+
+/* 
+ * STALK codec
+ * 
+ * @repository 		
+ * @author 		
+ *
+ */
+
+"use strict";
+
+/*
+	    0  1  2  3 
+       	    |  |  |  | 
+     $STALK,xx,yy,nn*CS 
+where:
+        STALK     	Raymarine Seatalk1 datagram sentence
+0 			00-9C       	Datagram type 
+1 			hex       	First datagram content 
+2 			hex   		Last datagram content 
+3 			hex      	Checksum 
+
+$STALK,9C,E1,15,00*4B
+*/
+
+var Codec = require('../lib/NMEA0183');
+
+module.exports = new Codec('STALK', function(multiplexer, input) {
+  var values = input.values;
+
+multiplexer.self();
+
+var x = parseInt(values[0], 16);
+switch(x){
+case 0x00:	/*depth*/
+  break;
+case 0x10:	/*Wind angle*/
+  break;
+case 0x11:	/*Wind speed*/
+  break;
+case 0x20:	/*Speed through water*/
+  break;
+case 0x21:	/*Trip Mileage*/
+  break;
+case 0x22:	/*Total Mileage*/
+  break;
+case 0x23:	/*Water Temperature*/
+  break;
+case 0x25:	/*Total Trip & Log*/
+  break;
+case 0x26:	/*Speed Through Water*/
+  break;
+case 0x27:	/*Water Temperature*/
+  break;
+case 0x30:	/*Set Lamp intensity*/
+  break;
+case 0x50:	/*Latitude*/
+  break;
+case 0x51:	/*Longitude*/
+  break;
+case 0x52:	/*Speed over Ground*/
+  break;
+case 0x53:	/*Magnetic Course*/
+  break;
+case 0x54:	/*UTC Time*/
+  break;
+case 0x56:	/*Date*/
+  break;
+case 0x80:	/*Set lamp intensity*/
+  break;
+case 0x84:	/*Compass heading and turning direction, autopilot course, active mode (standby, auto , wind, track) and rudden position*/
+  var U = parseInt(values[1].charAt(0),16);
+  var VW = parseInt(values[2],16);
+  var V = parseInt(values[2].charAt(0),16);
+  var XY = parseInt(values[3],16);
+  var Z = parseInt(values[4].charAt(1),16);
+  var M = parseInt(values[5].charAt(1),16);
+  var RR = parseInt(values[6],16);
+  var SS = parseInt(values[7],16);
+  var TT = parseInt(values[8],16);
+  var compassHeading = (U & 0x3)*90 + (VW & 0x3F) *2 + (U & 0xC ? (U & 0xC == 0xC ? 2 : 1): 0);
+
+  var apCourse = (V & 0xC0) * 90 + (XY) / 2;
+
+ 	/*Positive to right*/
+var rudderPos = RR;
+  if (rudderPos > 127) { rudderPos = rudderPos - 256};
+
+var modeVar = (Z & 0x2);
+  switch(modeVar){
+    case 0: var mode = "standby";
+	break;
+    case 2: var mode = "auto";
+	break;
+    default: break;
+    }
+if ((Z & 0x4) == 4) {
+  var mode = "wind";
+}
+if ((Z & 0x8) == 8) {
+  var mode = "route"; 
+}
+
+  var pathValues = []
+  if (compassHeading) {
+    pathValues.push({
+      path: 'navigation.headingMagnetic',
+      value: this.transform(this.float(compassHeading), 'deg', 'rad')
+    })
+  }
+  if (apCourse) {
+    pathValues.push({
+      path: 'steering.autopilot.target.headingMagnetic',
+      value: this.transform(this.float(apCourse), 'deg', 'rad')
+    })
+  }
+  if (rudderPos) {
+    pathValues.push({
+      path: 'steering.rudderAngle',
+      value: this.transform(this.float(rudderPos), 'deg', 'rad')
+    })
+  }
+  if (mode) {
+    pathValues.push({
+      path: 'steering.autopilot.state',
+      value: mode
+    })
+  }                
+
+  if (pathValues.length > 0) {
+    multiplexer.add({
+      "updates": [{
+        "source": this.source(input.instrument),
+        "timestamp": this.timestamp(),
+        "values": pathValues
+      }],
+      "context": multiplexer._context
+    });
+  }
+  return true;
+
+  break;
+case 0x85:	/*Navigation to waypoint information*/
+  break;
+case 0x86:	/*Keystroke*/
+  break;
+case 0x87:	/*Set response level*/
+  break;
+case 0x88:	/*Autopilot Parameter*/
+
+  break;
+case 0x89:	/*Compass heading sent by ST40 compass instrument*/
+  break;
+case 0x91:	/*Set rudder gain*/
+  break;
+case 0x92:	/*Set autopilot parameter*/
+  break;
+case 0x99: 	/*Compass variation*/
+  break;
+case 0x9C:	/*Compass heading and turning direction*/
+
+  break;
+default:
+  break;
+}
+
+});
+

--- a/codecs/index.js
+++ b/codecs/index.js
@@ -43,6 +43,7 @@ var codecs = {
   VDR: require('./VDR'),
   VPW: require('./VPW'),
   VWR: require('./VWR'),
+  STALK: require('./STALK'),
 };
 
 module.exports = codecs;

--- a/lib/index.js
+++ b/lib/index.js
@@ -100,6 +100,12 @@ Parser.prototype._lineData = function(sentence) {
       type: values[0].slice(-3),
       values: []
     };
+  } else if (values[0] == "STALK") {
+    var data = {
+      instrument: "seatalk",
+      type: values[0],
+      values: []
+    };
   } else {
     var data = {
       instrument: values[0].slice(0, 2),

--- a/test/STALK.js
+++ b/test/STALK.js
@@ -1,0 +1,103 @@
+var chai = require("chai");
+chai.Should();
+chai.use(require('chai-things'));
+
+
+var heading = "$STALK,84,B6,10,00,00,00,00,00,00*14"
+var standby = "$STALK,84,E6,15,00,00,00,00,00,08*1E"
+var auto = "$STALK,84,86,09,0B,02,00,00,00,08*1E"
+var wind = "$STALK,84,06,00,00,04,00,00,00,00*63"
+var route = "$STALK,84,06,00,00,08,00,00,00,00*6F"
+var rudder = "$STALK,84,06,00,00,08,00FE,00,00*6C"
+
+parser = new(require('../lib/').Parser)();
+
+describe('STALK', function(done) {
+  it('0x84 heading converted', function(done) {
+    var parser = new(require('../lib/').Parser)({
+      selfId: 'urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d'
+    });
+    parser.on('delta', function(delta) {
+            delta.updates[0].values.should.include({
+        'path': 'navigation.headingMagnetic',
+        'value': 5.305800926062761
+      });
+      delta.should.be.validSignalKDelta;
+      done();
+    });
+    parser.write(heading);
+  })
+  it('0x84 ap mode: standby converted', function(done) {
+    var parser = new(require('../lib/').Parser)();
+    parser.on('delta', function(delta) {
+            delta.updates[0].values.should.include({
+        'path': 'steering.autopilot.state',
+        'value': "standby"
+      });
+      delta.should.be.validSignalKDelta;
+      done();
+    });
+    parser.write(standby);
+  })
+  it('0x84 ap mode: auto converted', function(done) {
+    var parser = new(require('../lib/').Parser)();
+    parser.on('delta', function(delta) {
+            delta.updates[0].values.should.include({
+        'path': 'steering.autopilot.state',
+        'value': "auto"
+      });
+      delta.should.be.validSignalKDelta;
+      done();
+    });
+    parser.write(auto);
+  })
+  it('0x84 ap mode: wind converted', function(done) {
+    var parser = new(require('../lib/').Parser)();
+    parser.on('delta', function(delta) {
+            delta.updates[0].values.should.include({
+        'path': 'steering.autopilot.state',
+        'value': "wind"
+      });
+      delta.should.be.validSignalKDelta;
+      done();
+    });
+    parser.write(wind);
+  })
+  it('0x84 ap mode: route converted', function(done) {
+    var parser = new(require('../lib/').Parser)();
+    parser.on('delta', function(delta) {
+            delta.updates[0].values.should.include({
+        'path': 'steering.autopilot.state',
+        'value': "route"
+      });
+      delta.should.be.validSignalKDelta;
+      done();
+    });
+    parser.write(route);
+  })
+  it('0x84 rudder angle converted', function(done) {
+    var parser = new(require('../lib/').Parser)();
+    parser.on('delta', function(delta) {
+            delta.updates[0].values.should.include({
+        'path': 'steering.rudderAngle',
+        'value': -0.03490658503988659
+      });
+      delta.should.be.validSignalKDelta;
+      done();
+    });
+    parser.write(rudder);
+    done();
+  })
+  it('0x84 ap target heading  converted', function(done) {
+    var parser = new(require('../lib/').Parser)();
+    parser.on('delta', function(delta) {
+            delta.updates[0].values.should.include({
+        'path': 'steering.autopilot.target.headingMagnetic',
+        'value': 0.09599310885968812
+      });
+      delta.should.be.validSignalKDelta;
+      done();
+    });
+    parser.write(auto);
+  })
+});

--- a/test/STALK.js
+++ b/test/STALK.js
@@ -5,10 +5,11 @@ chai.use(require('chai-things'));
 
 var heading = "$STALK,84,B6,10,00,00,00,00,00,00*14"
 var standby = "$STALK,84,E6,15,00,00,00,00,00,08*1E"
-var auto = "$STALK,84,86,09,0B,02,00,00,00,08*1E"
+var auto = "$STALK,84,56,5E,79,02,00,00,00,08*16"
 var wind = "$STALK,84,06,00,00,04,00,00,00,00*63"
 var route = "$STALK,84,06,00,00,08,00,00,00,00*6F"
 var rudder = "$STALK,84,06,00,00,08,00FE,00,00*6C"
+var heading_nineC = "$STALK,9C,51,1E,00*4B"
 
 parser = new(require('../lib/').Parser)();
 
@@ -93,11 +94,23 @@ describe('STALK', function(done) {
     parser.on('delta', function(delta) {
             delta.updates[0].values.should.include({
         'path': 'steering.autopilot.target.headingMagnetic',
-        'value': 0.09599310885968812
+        'value': 2.626720524251466
       });
       delta.should.be.validSignalKDelta;
       done();
     });
     parser.write(auto);
+  })
+  it('0x9C ap target heading  converted', function(done) {
+    var parser = new(require('../lib/').Parser)();
+    parser.on('delta', function(delta) {
+            delta.updates[0].values.should.include({
+        'path': 'navigation.headingMagnetic',
+        'value': 2.6529004630313806
+      });
+      delta.should.be.validSignalKDelta;
+      done();
+    });
+    parser.write(heading_nineC);
   })
 });


### PR DESCRIPTION
Seatalk1 units should be able to speak NMEA, or at least there are translators available from seatalk1 to NMEA0183, but for more fine grained information, there are some pieces of the puzzle that are not available in NMEA0183. Some units like this one http://www.gadgetpool.de/bestellen/catalog/product_info.php/products_id/54
provide seatalk1 datagrams enclosed in a $STALK sentence. This is an attempt of getting seatalk info from $STALK into SignalK. Now the procedure could be different, and I hope you have some specific input (architecture etc). The STALK.js file may become cumbersomely large if this expands, so it may be necessary to split the different datagram decoders into separate files, but I have not managed to do so. 

The only datagram that has been populated is 0x84, but this provides compass heading, target heading, autopilot mode and rudder angle from seatalk1 autopilots. 