### PR TITLE
Split seatalk datagrams

### DIFF
--- a/codecs/STALK.js
+++ b/codecs/STALK.js
@@ -51,9 +51,4 @@ module.exports = new Codec('STALK', function(multiplexer, input) {
     return datagrams[x](values, multiplexer, input.instrument)
   }
   return false
-<<<<<<< HEAD
 });
-
-=======
-});
->>>>>>> seatalk-exp

--- a/codecs/STALK.js
+++ b/codecs/STALK.js
@@ -51,5 +51,9 @@ module.exports = new Codec('STALK', function(multiplexer, input) {
     return datagrams[x](values, multiplexer, input.instrument)
   }
   return false
+<<<<<<< HEAD
 });
 
+=======
+});
+>>>>>>> seatalk-exp

--- a/codecs/STALK.js
+++ b/codecs/STALK.js
@@ -1,5 +1,10 @@
 /*
  * Copyright 2016 Joachim Bakke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -7,7 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
+
+
 
 /*
  * STALK codec
@@ -29,6 +36,7 @@ where:
 1 			hex       	First datagram content
 2 			hex   		Last datagram content
 3 			hex      	Checksum
+
 */
 
 var Codec = require('../lib/NMEA0183');
@@ -44,3 +52,4 @@ module.exports = new Codec('STALK', function(multiplexer, input) {
   }
   return false
 });
+

--- a/codecs/STALK.js
+++ b/codecs/STALK.js
@@ -40,16 +40,14 @@ where:
 */
 
 var Codec = require('../lib/NMEA0183');
-var datagrams = require('./stalk/')
+var datagrams = require('./stalk/');
 
 module.exports = new Codec('STALK', function(multiplexer, input) {
   var values = input.values;
-console.log("datagram(1): " + values[0]);
   multiplexer.self();
 
   var x = parseInt(values[0], 16);
   if(datagrams[x]) {
-console.log("datagram: " + x);
     return datagrams[x](values, multiplexer, input.instrument)
   }
   return false

--- a/codecs/STALK.js
+++ b/codecs/STALK.js
@@ -1,10 +1,5 @@
 /*
  * Copyright 2016 Joachim Bakke
- * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,150 +9,38 @@
  * limitations under the License.
 */
 
-
-
-/* 
+/*
  * STALK codec
- * 
- * @repository 		
- * @author 		
+ *
+ * @repository
+ * @author
  *
  */
 
 "use strict";
 
 /*
-	    0  1  2  3 
-       	    |  |  |  | 
-     $STALK,xx,yy,nn*CS 
+	    0  1  2  3
+       	    |  |  |  |
+     $STALK,xx,yy,nn*CS
 where:
         STALK     	Raymarine Seatalk1 datagram sentence
-0 			00-9C       	Datagram type 
-1 			hex       	First datagram content 
-2 			hex   		Last datagram content 
-3 			hex      	Checksum 
-
+0 			00-9C       	Datagram type
+1 			hex       	First datagram content
+2 			hex   		Last datagram content
+3 			hex      	Checksum
 */
 
 var Codec = require('../lib/NMEA0183');
+var datagrams = require('./stalk/')
 
 module.exports = new Codec('STALK', function(multiplexer, input) {
   var values = input.values;
+  multiplexer.self();
 
-multiplexer.self();
-
-var x = parseInt(values[0], 16);
-switch(x){
-case 0x84:	/*Compass heading and turning direction, autopilot course, active mode (standby, auto , wind, track) and rudden position*/
-  var U = parseInt(values[1].charAt(0),16);
-  var VW = parseInt(values[2],16);
-  var V = parseInt(values[2].charAt(0),16);
-  var XY = values[3];
-  var Z = parseInt(values[4].charAt(1),16);
-  var M = parseInt(values[5].charAt(1),16);
-  var RR = parseInt(values[6],16);
-  var SS = parseInt(values[7],16);
-  var TT = parseInt(values[8],16);
-  var compassHeading = (U & 0x3)*90 + (VW & 0x3F) *2 + (U & 0xC ? (U & 0xC == 0xC ? 2 : 1): 0);
-  var apCourse = ((V & 0xC )>> 2)* 90 + parseInt(XY,16)/ 2;
- 	/*Positive to right*/
-var rudderPos = RR;
-  if (rudderPos > 127) { rudderPos = rudderPos - 256};
-
-var modeVar = (Z & 0x2);
-  switch(modeVar){
-    case 0: var mode = "standby";
-	break;
-    case 2: var mode = "auto";
-	break;
-    default: break;
-    }
-if ((Z & 0x4) == 4) {
-  var mode = "wind";
-}
-if ((Z & 0x8) == 8) {
-  var mode = "route"; 
-}
-
-  var pathValues = []
-  if (compassHeading) {
-    pathValues.push({
-      path: 'navigation.headingMagnetic',
-      value: this.transform(this.float(compassHeading), 'deg', 'rad')
-    })
+  var x = parseInt(values[0], 16);
+  if(datagrams[x]) {
+    return datagrams[x](values, multiplexer, input.instrument)
   }
-  if (apCourse) {
-    pathValues.push({
-      path: 'steering.autopilot.target.headingMagnetic',
-      value: this.transform(this.float(apCourse), 'deg', 'rad')
-    })
-  }
-  if (rudderPos) {
-    pathValues.push({
-      path: 'steering.rudderAngle',
-      value: this.transform(this.float(rudderPos), 'deg', 'rad')
-    })
-  }
-  if (mode) {
-    pathValues.push({
-      path: 'steering.autopilot.state',
-      value: mode
-    })
-  }                
-
-  if (pathValues.length > 0) {
-    multiplexer.add({
-      "updates": [{
-        "source": this.source(input.instrument),
-        "timestamp": this.timestamp(),
-        "values": pathValues
-      }],
-      "context": multiplexer._context
-    });
-  }
-  return true;
-
-  break;
-case 0x9C:	/*Compass heading and turning direction*/
-  var U = parseInt(values[1].charAt(0),16);
-  var VW = parseInt(values[2],16);
-  var RR = parseInt(values[3],16);
-
-  var compassHeading = (U & 0x3)*90 + (VW & 0x3F) *2 + (U & 0xC ? (U & 0xC == 0xC ? 2 : 1): 0);
-  var rudderPos = RR;
-  if (rudderPos > 127) { rudderPos = rudderPos - 256};
-    
-  
-  var pathValues = []
-  if (compassHeading) {
-    pathValues.push({
-      path: 'navigation.headingMagnetic',
-      value: this.transform(this.float(compassHeading), 'deg', 'rad')
-    })
-  }
-  if (rudderPos) {
-    pathValues.push({
-      path: 'steering.rudderAngle',
-      value: this.transform(this.float(rudderPos), 'deg', 'rad')
-    })
-  }
-
-  if (pathValues.length > 0) {
-    multiplexer.add({
-      "updates": [{
-        "source": this.source(input.instrument),
-        "timestamp": this.timestamp(),
-        "values": pathValues
-      }],
-      "context": multiplexer._context
-    });
-  }
-  return true;
-  break;
-
-default:
-  break;
-}
-
+  return false
 });
-

--- a/codecs/STALK.js
+++ b/codecs/STALK.js
@@ -44,10 +44,12 @@ var datagrams = require('./stalk/')
 
 module.exports = new Codec('STALK', function(multiplexer, input) {
   var values = input.values;
+console.log("datagram(1): " + values[0]);
   multiplexer.self();
 
   var x = parseInt(values[0], 16);
   if(datagrams[x]) {
+console.log("datagram: " + x);
     return datagrams[x](values, multiplexer, input.instrument)
   }
   return false

--- a/codecs/stalk/0x84.js
+++ b/codecs/stalk/0x84.js
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
- var Codec = require('../../lib/NMEA0183')
+
+var Codec = require('../../lib/NMEA0183');
 
 
 module.exports = function(values, multiplexer, instrument) {

--- a/codecs/stalk/0x84.js
+++ b/codecs/stalk/0x84.js
@@ -1,4 +1,20 @@
-var Codec = require('../../lib/NMEA0183')
+/*
+ * Copyright 2016 Joachim Bakke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ var Codec = require('../../lib/NMEA0183')
 
 
 module.exports = function(values, multiplexer, instrument) {

--- a/codecs/stalk/0x84.js
+++ b/codecs/stalk/0x84.js
@@ -1,0 +1,79 @@
+var Codec = require('../../lib/NMEA0183')
+
+
+module.exports = function(values, multiplexer, instrument) {
+
+  /*Compass heading and turning direction, autopilot course, active mode (standby, auto , wind, track) and rudder position*/
+  var U = parseInt(values[1].charAt(0), 16);
+  var VW = parseInt(values[2], 16);
+  var V = parseInt(values[2].charAt(0), 16);
+  var XY = values[3];
+  var Z = parseInt(values[4].charAt(1), 16);
+  var M = parseInt(values[5].charAt(1), 16);
+  var RR = parseInt(values[6], 16);
+  var SS = parseInt(values[7], 16);
+  var TT = parseInt(values[8], 16);
+  var compassHeading = (U & 0x3) * 90 + (VW & 0x3F) * 2 + (U & 0xC ? (U & 0xC == 0xC ? 2 : 1) : 0);
+  var apCourse = ((V & 0xC) >> 2) * 90 + parseInt(XY, 16) / 2;
+  /*Positive to right*/
+  var rudderPos = RR;
+  if(rudderPos > 127) {
+    rudderPos = rudderPos - 256
+  };
+
+  var modeVar = (Z & 0x2);
+  switch(modeVar) {
+    case 0:
+      var mode = "standby";
+      break;
+    case 2:
+      var mode = "auto";
+      break;
+    default:
+      break;
+  }
+  if((Z & 0x4) == 4) {
+    var mode = "wind";
+  }
+  if((Z & 0x8) == 8) {
+    var mode = "route";
+  }
+
+  var pathValues = []
+  if(compassHeading) {
+    pathValues.push({
+      path: 'navigation.headingMagnetic',
+      value: Codec.prototype.transform(Codec.prototype.float(compassHeading), 'deg', 'rad')
+    })
+  }
+  if(apCourse) {
+    pathValues.push({
+      path: 'steering.autopilot.target.headingMagnetic',
+      value: Codec.prototype.transform(Codec.prototype.float(apCourse), 'deg', 'rad')
+    })
+  }
+  if(rudderPos) {
+    pathValues.push({
+      path: 'steering.rudderAngle',
+      value: Codec.prototype.transform(Codec.prototype.float(rudderPos), 'deg', 'rad')
+    })
+  }
+  if(mode) {
+    pathValues.push({
+      path: 'steering.autopilot.state',
+      value: mode
+    })
+  }
+
+  if(pathValues.length > 0) {
+    multiplexer.add({
+      "updates": [{
+        "source": Codec.prototype.source(instrument),
+        "timestamp": Codec.prototype.timestamp(),
+        "values": pathValues
+      }],
+      "context": multiplexer._context
+    });
+  }
+  return true;
+}

--- a/codecs/stalk/0x9c.js
+++ b/codecs/stalk/0x9c.js
@@ -1,0 +1,41 @@
+var Codec = require('../../lib/NMEA0183')
+
+module.exports = function(values, multiplexer, instrument) {
+  /*Compass heading and turning direction*/
+  var U = parseInt(values[1].charAt(0), 16);
+  var VW = parseInt(values[2], 16);
+  var RR = parseInt(values[3], 16);
+
+  var compassHeading = (U & 0x3) * 90 + (VW & 0x3F) * 2 + (U & 0xC ? (U & 0xC == 0xC ? 2 : 1) : 0);
+  var rudderPos = RR;
+  if(rudderPos > 127) {
+    rudderPos = rudderPos - 256
+  };
+
+
+  var pathValues = []
+  if(compassHeading) {
+    pathValues.push({
+      path: 'navigation.headingMagnetic',
+      value: Codec.prototype.transform(Codec.prototype.float(compassHeading), 'deg', 'rad')
+    })
+  }
+  if(rudderPos) {
+    pathValues.push({
+      path: 'steering.rudderAngle',
+      value: Codec.prototype.transform(Codec.prototype.float(rudderPos), 'deg', 'rad')
+    })
+  }
+
+  if(pathValues.length > 0) {
+    multiplexer.add({
+      "updates": [{
+        "source": Codec.prototype.source(instrument),
+        "timestamp": Codec.prototype.timestamp(),
+        "values": pathValues
+      }],
+      "context": multiplexer._context
+    });
+  }
+  return true
+}

--- a/codecs/stalk/0x9c.js
+++ b/codecs/stalk/0x9c.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
  
+
 var Codec = require('../../lib/NMEA0183')
 
 module.exports = function(values, multiplexer, instrument) {

--- a/codecs/stalk/0x9c.js
+++ b/codecs/stalk/0x9c.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Joachim Bakke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
 var Codec = require('../../lib/NMEA0183')
 
 module.exports = function(values, multiplexer, instrument) {

--- a/codecs/stalk/index.js
+++ b/codecs/stalk/index.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016, Teppo Kurki
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+var datagrams = {
+	0x84: require('./0x84'),
+	0x9c: require('./0x9c'),
+}
+module.exports = datagrams;

--- a/codecs/stalk/index.js
+++ b/codecs/stalk/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Teppo Kurki
+ * Copyright 2016 Joachim Bakke
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -102,8 +102,8 @@ Parser.prototype._lineData = function(sentence) {
     };
   } else if (values[0] == "STALK") {
     var data = {
-      instrument: "seatalk",
-      type: values[0],
+      instrument: values[0].slice(0, 2),
+      type: values[0].slice(-3),
       values: []
     };
   } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -102,8 +102,8 @@ Parser.prototype._lineData = function(sentence) {
     };
   } else if (values[0] == "STALK") {
     var data = {
-      instrument: values[0].slice(0, 2),
-      type: values[0].slice(-3),
+      instrument: values[0].slice(0, 5),
+      type: values[0],
       values: []
     };
   } else {

--- a/test/STALK.js
+++ b/test/STALK.js
@@ -24,7 +24,7 @@ var standby = "$STALK,84,E6,15,00,00,00,00,00,08*1E"
 var auto = "$STALK,84,56,5E,79,02,00,00,00,08*16"
 var wind = "$STALK,84,06,00,00,04,00,00,00,00*63"
 var route = "$STALK,84,06,00,00,08,00,00,00,00*6F"
-var rudder = "$STALK,84,06,00,00,08,00,FE,00,00*5C"
+var rudder = "$STALK,84,06,00,00,08,00,FE,00,00*6C"
 var heading_nineC = "$STALK,9C,51,1E,00*4B"
 
 parser = new(require('../lib/').Parser)();

--- a/test/STALK.js
+++ b/test/STALK.js
@@ -24,7 +24,7 @@ var standby = "$STALK,84,E6,15,00,00,00,00,00,08*1E"
 var auto = "$STALK,84,56,5E,79,02,00,00,00,08*16"
 var wind = "$STALK,84,06,00,00,04,00,00,00,00*63"
 var route = "$STALK,84,06,00,00,08,00,00,00,00*6F"
-var rudder = "$STALK,84,06,00,00,08,00FE,00,00*6C"
+var rudder = "$STALK,84,06,00,00,08,00,FE,00,00*5C"
 var heading_nineC = "$STALK,9C,51,1E,00*4B"
 
 parser = new(require('../lib/').Parser)();

--- a/test/STALK.js
+++ b/test/STALK.js
@@ -40,9 +40,9 @@ describe('STALK', function(done) {
         'value': 5.305800926062761
       });
       delta.should.be.validSignalKDelta;
-      done();
     });
     parser.write(heading);
+    done();
   })
   it('0x84 ap mode: standby converted', function(done) {
     var parser = new(require('../lib/').Parser)();
@@ -52,9 +52,9 @@ describe('STALK', function(done) {
         'value': "standby"
       });
       delta.should.be.validSignalKDelta;
-      done();
     });
     parser.write(standby);
+    done();
   })
   it('0x84 ap mode: auto converted', function(done) {
     var parser = new(require('../lib/').Parser)();
@@ -64,9 +64,9 @@ describe('STALK', function(done) {
         'value': "auto"
       });
       delta.should.be.validSignalKDelta;
-      done();
     });
     parser.write(auto);
+    done();
   })
   it('0x84 ap mode: wind converted', function(done) {
     var parser = new(require('../lib/').Parser)();
@@ -76,9 +76,9 @@ describe('STALK', function(done) {
         'value': "wind"
       });
       delta.should.be.validSignalKDelta;
-      done();
     });
     parser.write(wind);
+    done();
   })
   it('0x84 ap mode: route converted', function(done) {
     var parser = new(require('../lib/').Parser)();
@@ -88,9 +88,9 @@ describe('STALK', function(done) {
         'value': "route"
       });
       delta.should.be.validSignalKDelta;
-      done();
     });
     parser.write(route);
+    done();
   })
   it('0x84 rudder angle converted', function(done) {
     var parser = new(require('../lib/').Parser)();
@@ -100,7 +100,6 @@ describe('STALK', function(done) {
         'value': -0.03490658503988659
       });
       delta.should.be.validSignalKDelta;
-      done();
     });
     parser.write(rudder);
     done();
@@ -113,9 +112,9 @@ describe('STALK', function(done) {
         'value': 2.626720524251466
       });
       delta.should.be.validSignalKDelta;
-      done();
     });
     parser.write(auto);
+    done();
   })
   it('0x9C ap target heading  converted', function(done) {
     var parser = new(require('../lib/').Parser)();
@@ -125,8 +124,9 @@ describe('STALK', function(done) {
         'value': 2.6529004630313806
       });
       delta.should.be.validSignalKDelta;
-      done();
     });
     parser.write(heading_nineC);
+    done();
   })
 });
+

--- a/test/STALK.js
+++ b/test/STALK.js
@@ -1,4 +1,20 @@
-var chai = require("chai");
+/*
+ * Copyright 2016 Joachim Bakke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ var chai = require("chai");
 chai.Should();
 chai.use(require('chai-things'));
 


### PR DESCRIPTION
The seatalk1 datagrams are split out for ease of maintenance/reading and allows direct seatalk datagrams to be decoded without the $STALK wrapper