### PR TITLE
Fix #78: de-singleton ais session

### DIFF
--- a/codecs/VDM.js
+++ b/codecs/VDM.js
@@ -27,10 +27,9 @@ as a global singleton. Proper implementation would be
 a per stream constructer NMEA0183 encoder that would be able
 to keep a coherent internal parsing state.
 */
-var session = {};
 
 module.exports = new Codec('VDM', function(multiplexer, input, line) {
-  var data = new Decoder(line, session);
+  var data = new Decoder(line, multiplexer.aisSession);
 
   if (!data.valid) {
     return this.reportError(this.errors.VOID, "Not parsing sentence for it isn't valid.");

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,6 +46,7 @@ function Parser(opts) {
   this.self.type = this._options.selfType || 'uuid';
 
   this._multiplexer = new Multiplexer(this.self.id, this.self.type);
+  this._multiplexer.aisSession = {};
   this._codecs = require('../codecs');
 
   this._multiplexer.on('change', function() {

--- a/test/VDM.js
+++ b/test/VDM.js
@@ -2,20 +2,24 @@ var chai = require("chai");
 chai.Should();
 chai.use(require('chai-things'));
 var signalkSchema = require('signalk-schema');
+const _ = require('lodash')
 
 
 
 var nmeaLines = [
   "!AIVDM,2,1,0,A,53brRt4000010SG;700iE@LE8@Tp4000000000153P615t0Ht0SCkjH4jC1C,0*1E\n",
-  "!AIVDM,2,2,0,A,`0000000001,2*75\n"
+  "!AIVDM,2,2,0,A,`0000000001,2*75\n",
+  '!AIVDM,2,1,0,A,58wt8Ui`g??r21`7S=:22058<v05Htp000000015>8OA;0sk,0*7B\n',
+  '!AIVDM,2,2,0,A,eQ8823mDm3kP00000000000,2*5D\n'
 ];
 
 describe('VDM', function() {
   it(' multiline converts ok', function(done) {
-    var parser = new(require('../lib/').Parser)({
+    const countDones = _.after(2, done)
+    var parser1 = new(require('../lib/').Parser)({
       selfId: 'urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d'
     });
-    parser.on('delta', function(delta) {
+    parser1.on('delta', function(delta) {
       // validate schema conformance
       var full = signalkSchema.deltaToFull(delta);
       signalkSchema.fillIdentity(full);
@@ -23,10 +27,26 @@ describe('VDM', function() {
 
       full.vessels['urn:mrn:imo:mmsi:246326000'].should.have.property('mmsi', '246326000');
       full.vessels['urn:mrn:imo:mmsi:246326000'].should.have.property('name', 'LUTGERDINA');
-      done();
+      countDones();
     });
-    parser.write(nmeaLines[0]);
-    parser.write(nmeaLines[1]);
+
+    var parser2 = new(require('../lib/').Parser)({
+      selfId: 'urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021e'
+    });
+    parser2.on('delta', function(delta) {
+      // validate schema conformance
+      var full = signalkSchema.deltaToFull(delta);
+      signalkSchema.fillIdentity(full);
+      full.should.be.validSignalK;
+
+      full.vessels['urn:mrn:imo:mmsi:603916439'].should.have.property('mmsi', '603916439');
+      full.vessels['urn:mrn:imo:mmsi:603916439'].should.have.property('name', '   ARCO AVON');
+      countDones();
+    });
+    parser1.write(nmeaLines[0]);
+    parser2.write(nmeaLines[2]);
+    parser1.write(nmeaLines[1]);
+    parser2.write(nmeaLines[3]);
   })
 
   it(' single line converts ok', function(done) {


### PR DESCRIPTION
Ais session has been a singleton, which will mess things up
if you run several Parsers concurrently and they have ais data.
The session is monkeypatched to multiplexer, which is the only
available context in consecutive invocations.

Fixes #78.