### PR TITLE
correct timestamp RMC

### DIFF
--- a/lib/NMEA0183.js
+++ b/lib/NMEA0183.js
@@ -181,7 +181,7 @@
     if (date) {
       var year, month, day;
       day = this.int(date.slice(0, 2), true);
-      month = this.int(date.slice(2, 4), true);
+      month = this.int(date.slice(2, 4)-1, true);
       year = this.int(date.slice(-2));
 
       // HACK copied from jamesp/node-nmea


### PR DESCRIPTION
 Month for January is 0 not 1. So it was one month to high.