### PR TITLE
Emit "nmea0183" event before a sentence is parsed

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,10 @@ class Parser extends EventEmitter {
   }
 
   parse (sentence) {
+    if (typeof sentence === 'string' && sentence.trim().length > 0) {
+      this.emit('nmea0183', sentence.trim())
+    }
+
     return parseSentence(this, sentence)
       .then(result => {
         if (typeof result === 'object' && result !== null) {


### PR DESCRIPTION
When an application or user executes the `Parser#parse(sentence)` method, the method checks if the sentence is a non-empty string and emits a `nmea0183` event with that sentence. 