### PR TITLE
Do not include a key named 'delta' with delta data in output

### DIFF
--- a/bin/nmea0183-signalk
+++ b/bin/nmea0183-signalk
@@ -15,7 +15,7 @@ process.stdin.on('data', data => {
   parser
     .parse(data)
     .then(result => {
-      console.log(JSON.stringify(result))
+      console.log(JSON.stringify(result.delta))
     })
     .catch(e => {
       console.error('Encountered an error:', e.message)


### PR DESCRIPTION
Instead output the delta directly like the n2k-parser program does.

This fixes #104.