### PR TITLE
refactor: more efficient findHook

### DIFF
--- a/lib/findHook.js
+++ b/lib/findHook.js
@@ -2,34 +2,31 @@
 
 /**
  * Copyright 2016 Signal K and Fabian Tollenaar <fabian@signalk.org>.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 const debug = require('debug')('signalk-parser-nmea0183/findHook')
 const fs = require('fs')
 const path = require('path').join(__dirname, '../hooks')
 
-module.exports = function findHook(id) {
-  let found = false
-
-  try {
-    found = (typeof fs.statSync(`${path}/${id}.js`) === 'object')
-  } catch (e) {}
-
-  if (found === true) {
-    return require(`../hooks/${id}.js`)
-  }
-
-  return false
+const hooks = {}
+fs
+  .readdirSync(path)
+  .filter(filename => filename.indexOf('.') > 0)
+  .forEach(filename => {
+    hooks[filename.split('.')[0]] = require(`../hooks/${filename}`)
+  })
+module.exports = function findHook (id) {
+  return hooks[id]
 }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -56,7 +56,7 @@ module.exports = function parseSentence(emitter, sentence) {
     tags.source = `${tags.source}:${id}`
   }
 
-  if (hook === false) {
+  if (!hook) {
     emitter.emit('warning', { message: `No hook found for "${sentence.trim()}"` })
     return Promise.resolve(null)
   }


### PR DESCRIPTION
Require the hooks once upon startup, foregoing the synchronous
file system access for each sentence.