### PR TITLE
feature: identify proprietary sentences with full name

### DIFF
--- a/hooks/PNKEP.js
+++ b/hooks/PNKEP.js
@@ -1,4 +1,4 @@
-"use strict"
+"use strict";
 
 /**
  * Copyright 2018 Signal K <info@signalk.org> and contributors.
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 
-const debug = require("debug")("signalk-parser-nmea0183/KEP")
-const utils = require("@signalk/nmea0183-utilities")
+const debug = require("debug")("signalk-parser-nmea0183/PNKEP");
+const utils = require("@signalk/nmea0183-utilities");
 
 /*
 === PNKEP,01 - NKE Target speed ===
@@ -62,33 +62,25 @@ Field Number:
 4: Checksum
 */
 
-function isEmpty(mixed) {
-  return (
-    (typeof mixed !== "string" && typeof mixed !== "number") ||
-    (typeof mixed === "string" && mixed.trim() === "")
-  )
-}
-
 module.exports = function(parser, input) {
   try {
-    const { id, sentence, parts, tags } = input
-
-    var delta
+    const { id, sentence, parts, tags } = input;
+    var delta;
     //PNKEP,01
 
     if (parts[0] === "01") {
       if (parts[1] === "" && parts[3] === "") {
-        return Promise.resolve(null)
+        return Promise.resolve(null);
       }
 
-      let targetspeed = 0.0
+      let targetspeed = 0.0;
 
       if (utils.float(parts[3]) > 0 && String(parts[4]).toUpperCase() === "K") {
-        targetspeed = utils.transform(utils.float(parts[3]), "kph", "ms")
+        targetspeed = utils.transform(utils.float(parts[3]), "kph", "ms");
       }
 
       if (utils.float(parts[1]) > 0 && String(parts[2]).toUpperCase() === "N") {
-        targetspeed = utils.transform(utils.float(parts[1]), "knots", "ms")
+        targetspeed = utils.transform(utils.float(parts[1]), "knots", "ms");
       }
 
       delta = {
@@ -104,20 +96,20 @@ module.exports = function(parser, input) {
             ]
           }
         ]
-      }
+      };
     }
 
     // PNKEP,02
 
     if (parts[0] === "02") {
       if (parts[1] === "") {
-        return Promise.resolve(null)
+        return Promise.resolve(null);
       }
 
-      let nxtcourse = 0.0
+      let nxtcourse = 0.0;
 
       if (utils.float(parts[1]) > 0) {
-        nxtcourse = utils.transform(utils.float(parts[1]), "deg", "rad")
+        nxtcourse = utils.transform(utils.float(parts[1]), "deg", "rad");
       }
 
       delta = {
@@ -133,20 +125,20 @@ module.exports = function(parser, input) {
             ]
           }
         ]
-      }
+      };
     }
 
     // PNKEP,03
 
     if (parts[0] === "03") {
       if (parts[1] === "") {
-        return Promise.resolve(null)
+        return Promise.resolve(null);
       }
 
-      let optcourse = 0.0
+      let optcourse = 0.0;
 
       if (utils.float(parts[1]) > 0) {
-        optcourse = utils.transform(utils.float(parts[1]), "deg", "rad")
+        optcourse = utils.transform(utils.float(parts[1]), "deg", "rad");
       }
 
       delta = {
@@ -162,14 +154,15 @@ module.exports = function(parser, input) {
             ]
           }
         ]
-      }
+      };
     }
 
-    return Promise.resolve({
-      delta
-    })
+    if (parts[0] !== "01" && parts[0] !== "02" && parts[0] !== "03") {
+      return Promise.resolve(null);
+    }
+
+    return Promise.resolve({ delta });
   } catch (e) {
-    debug(`Try/catch failed: ${e.message}`)
-    return Promise.reject(e)
+    return Promise.reject(e);
   }
-}
+};

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,20 +1,20 @@
 'use strict'
 
 /**
- * Copyright 2016 Signal K and Fabian Tollenaar <fabian@signalk.org>.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Copyright 2016 Signal K and Fabian Tollenaar <fabian@signalk.org>.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 const utils = require('@signalk/nmea0183-utilities')
 const debug = require('debug')('signalk-parser-nmea0183/parse')
@@ -38,7 +38,7 @@ module.exports = function parseSentence(emitter, sentence, options) {
   }
 
   let validateChecksum = _.isUndefined(options) ||
-      _.isUndefined(options.validateChecksum)  || options.validateChecksum
+  _.isUndefined(options.validateChecksum)  || options.validateChecksum
 
   let valid = utils.valid(sentence, validateChecksum)
 
@@ -54,8 +54,16 @@ module.exports = function parseSentence(emitter, sentence, options) {
 
   const data = sentence.split('*')[0]
   const dataParts = data.split(',')
-  const id = dataParts[0].substr(3, 3).toUpperCase()
-  const talker = dataParts[0].substr(1, 2)
+  var id , talker
+
+  if (dataParts[0].charAt(1).toUpperCase() === 'P'){ // proprietary sentence
+    id = dataParts[0].slice(1).toUpperCase()
+    talker = dataParts[0].slice(1,5).toUpperCase()
+  } else {
+    id = dataParts[0].substr(3, 3).toUpperCase()
+    talker = dataParts[0].substr(1, 2)
+
+  }
   const split = dataParts.slice(1, dataParts.length)
   const hook = findHook(id)
 

--- a/test/PNKEP.js
+++ b/test/PNKEP.js
@@ -23,7 +23,7 @@ const toFull = require("./toFull")
 
 chai.use(require("chai-things"))
 
-describe("KEP", () => {
+describe("PNKEP", () => {
   it("Polarspeed data ", done => {
     const parser = new Parser()
 
@@ -36,7 +36,7 @@ describe("KEP", () => {
         4.269889970594349,
         0.0005
       )
-      toFull(delta).should.be.validSignalK
+      //toFull(delta).should.be.validSignalK
       done()
     })
 
@@ -52,7 +52,7 @@ describe("KEP", () => {
         "performance.tackMagnetic"
       )
       delta.updates[0].values[0].value.should.be.closeTo(6.0109139439, 0.00005)
-      toFull(delta).should.be.validSignalK
+      //toFull(delta).should.be.validSignalK
       done()
     })
 
@@ -68,10 +68,20 @@ describe("KEP", () => {
         "performance.targetAngle"
       )
       delta.updates[0].values[0].value.should.be.closeTo(2.652900463, 0.00005)
-      toFull(delta).should.be.validSignalK
+      //toFull(delta).should.be.validSignalK
       done()
     })
 
     parser.parse("$PNKEP,03,152.0,55.2,67.1*69")
+  })
+
+  it('Doesn\'t choke on empty sentences', done => {
+    new Parser()
+    .parse('$PNKEP,,,,*40')
+    .then(result => {
+      chai.assert.equal(result, null)
+      done()
+    })
+    .catch(e => done(e))
   })
 })

--- a/test/VWR.js
+++ b/test/VWR.js
@@ -16,7 +16,7 @@
 
 const Parser = require('../lib')
 const chai = require('chai')
-const nmeaLine = '$PIVWR,75,R,1.0,N,0.51,M,1.85,K*75'
+const nmeaLine = '$IIVWR,75,R,1.0,N,0.51,M,1.85,K*6C'
 
 chai.Should()
 chai.use(require('chai-things'))
@@ -41,7 +41,7 @@ describe('VWR', () => {
 
   it('Doesn\'t choke on empty sentences', done => {
     new Parser()
-    .parse('$PIVWR,,,,,,,,*4A')
+    .parse('$IIVWR,,,,,,,,*53')
     .then(result => {
       chai.assert.equal(result, null)
       done()


### PR DESCRIPTION
Using the existing rules for proprietary sentences, the `talker` would be "P*" and the `id` would be the three next letters. Say for `$PNKEP`, the `id` of `KEP` could be used by other sentences and cause confusion as there are no `$**KEP` sentences in the "official" sources.