### PR TITLE
Fix: VWR, ok if 4 empty fields (eg. fields 4-7)

### DIFF
--- a/hooks/VWR.js
+++ b/hooks/VWR.js
@@ -41,7 +41,7 @@ module.exports = function (parser, input) {
   const { id, sentence, parts, tags } = input
 
   const empty = parts.reduce((count, part) => { count += (isEmpty(part) ? 1 : 0); return count; }, 0)
-  if (empty > 3) {
+  if (empty > 4) {
     return Promise.resolve(null)
   }
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -39,10 +39,8 @@ module.exports = function parseSentence(emitter, sentence, options) {
 
   let validateChecksum = _.isUndefined(options) ||
       _.isUndefined(options.validateChecksum)  || options.validateChecksum
-  let acceptWithoutChecksum = _.isUndefined(options) ||
-      _.isUndefined(options.acceptWithoutChecksum)  || options.acceptWithoutChecksum
 
-  let valid = utils.valid(sentence, validateChecksum, acceptWithoutChecksum)
+  let valid = utils.valid(sentence, validateChecksum)
 
   if (valid === false) {
     emitter.emit('warning', { message: `Sentence "${sentence.trim()}" is invalid` })

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -39,8 +39,10 @@ module.exports = function parseSentence(emitter, sentence, options) {
 
   let validateChecksum = _.isUndefined(options) ||
       _.isUndefined(options.validateChecksum)  || options.validateChecksum
+  let acceptWithoutChecksum = _.isUndefined(options) ||
+      _.isUndefined(options.acceptWithoutChecksum)  || options.acceptWithoutChecksum
 
-  let valid = utils.valid(sentence, validateChecksum)
+  let valid = utils.valid(sentence, validateChecksum, acceptWithoutChecksum)
 
   if (valid === false) {
     emitter.emit('warning', { message: `Sentence "${sentence.trim()}" is invalid` })

--- a/test/VWR.js
+++ b/test/VWR.js
@@ -36,6 +36,21 @@ describe('VWR', () => {
     })
 
     parser.parse('$PIVWR,75,R,1.0,N,0.51,M,1.85,K*75')
+  })
+
+  it('Handles shorter valid sentences', done => {
+    const parser = new Parser
+
+    parser.on('signalk:delta', delta => {
+      delta.updates[0].values.should.contain.an.item.with.property('path', 'environment.wind.angleApparent')
+      delta.updates[0].values.should.contain.an.item.with.property('value', -0.41887902057428156)
+      delta.updates[0].values.should.contain.an.item.with.property('path', 'environment.wind.speedApparent')
+      delta.updates[0].values.should.contain.an.item.with.property('value', 9.260002345867262)
+
+
+      done()
+    })
+
     parser.parse('$IIVWR,024,L,018,N,,,,*5e')
   })
 

--- a/test/VWR.js
+++ b/test/VWR.js
@@ -16,7 +16,6 @@
 
 const Parser = require('../lib')
 const chai = require('chai')
-const nmeaLine = '$PIVWR,75,R,1.0,N,0.51,M,1.85,K*75'
 
 chai.Should()
 chai.use(require('chai-things'))
@@ -36,7 +35,8 @@ describe('VWR', () => {
       done()
     })
 
-    parser.parse(nmeaLine)
+    parser.parse('$PIVWR,75,R,1.0,N,0.51,M,1.85,K*75')
+    parser.parse('$IIVWR,024,L,018,N,,,,*5e')
   })
 
   it('Doesn\'t choke on empty sentences', done => {


### PR DESCRIPTION
Example sentence:  $IIVWR,024,L,018,N,,,,*5e   should be accepted (w/ 4 missing values)
var 'empty' not > 4 then continue / set environment.wind values.