### PR TITLE
refactor: do not use Promises internally

### DIFF
--- a/hooks/ALK.js
+++ b/hooks/ALK.js
@@ -38,13 +38,8 @@ module.exports = function(parser, input) {
   const { id, sentence, parts, tags } = input
   const key = '0x' + parseInt(parts[0],16).toString(16).toUpperCase()
   if (key in subHooks){
-    try {
-      return require(`${path}/${key}`)(parser, input)
-    } catch (e) {
-      return Promise.reject(e)
-    }
-
+    return require(`${path}/${key}`)(parser, input)
   } else {
-    return Promise.resolve(null)
+    return null
   }
 }

--- a/hooks/APB.js
+++ b/hooks/APB.js
@@ -2,20 +2,20 @@
 
 /**
  * Copyright 2016 Signal K and Fabian Tollenaar <fabian@signalk.org>.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 const debug = require('debug')('signalk-parser-nmea0183/APB')
 const utils = require('@signalk/nmea0183-utilities')
 
@@ -23,55 +23,50 @@ const utils = require('@signalk/nmea0183-utilities')
 
        0 1    2 3 4 5 6   7 8    9  10  11 12
        | |    | | | | |   | |    |   |  |  |
-$GPAPB,A,A,0.10,R,N,V,V,011,M,DEST,011,M,011,M*3C 
+$GPAPB,A,A,0.10,R,N,V,V,011,M,DEST,011,M,011,M*3C
 where:
         APB       Autopilot format B
-0       A         Loran-C blink/SNR warning, general warning 
-1       A         Loran-C cycle warning 
-2       0.10      cross-track error distance 
-3       R         steer Right to correct (or L for Left) 
-4       N         cross-track error units - nautical miles (K for kilometers) 
-5       V         arrival alarm - circle 
-6       V         arrival alarm - perpendicular 
-7,8     011,M     magnetic bearing, origin to destination 
-9       DEST      destination waypoint ID 
-10,11   011,M     magnetic bearing, present position to destination 
-12,13   011,M     magnetic heading to steer (bearings could True as 033,T) 
+0       A         Loran-C blink/SNR warning, general warning
+1       A         Loran-C cycle warning
+2       0.10      cross-track error distance
+3       R         steer Right to correct (or L for Left)
+4       N         cross-track error units - nautical miles (K for kilometers)
+5       V         arrival alarm - circle
+6       V         arrival alarm - perpendicular
+7,8     011,M     magnetic bearing, origin to destination
+9       DEST      destination waypoint ID
+10,11   011,M     magnetic bearing, present position to destination
+12,13   011,M     magnetic heading to steer (bearings could True as 033,T)
 *3C     Checksum
 
 */
 
 module.exports = function (parser, input) {
-  try {
-    const { id, sentence, parts } = input
-    
-    if(parts[0].toUpperCase() == 'V') {
-      // Don't parse this sentence as it's void.
-      return Promise.reject(new Error('Not parsing sentence for it\'s void (LORAN-C blink/SNR warning)'))
-    }
+  const { id, sentence, parts } = input
 
-    if(parts[1].toUpperCase() == 'V') {
-      return Promise.reject(new Error('Not parsing sentence for it\'s void (LORAN-C cycle warning)'))
-    }
-
-    const xte = utils.transform(parts[2], (parts[4].toUpperCase() === 'N' ? 'nm' : 'km'), 'm')
-
-    const currentRoute = {
-      source: utils.source(id),
-      timestamp: utils.timestamp(),
-      steer: (parts[3].toUpperCase() == 'R' ? 'right' : 'left'),
-      bearingActual: utils.transform(utils.float(parts[10]), 'deg', 'rad'),
-      bearingDirect: utils.transform(utils.float(parts[7]), 'deg', 'rad'),
-      courseRequired: utils.transform(utils.float(parts[12]), 'deg', 'rad'),
-      waypoint: {
-        next: parts[9],
-        xte: xte
-      }
-    }
-    
-    return Promise.reject(new Error('@FIXME: APB hook needs to be rewritten to fit latest version of SK'))
-  } catch (e) {
-    debug(`Try/catch failed: ${e.message}`)
-    return Promise.reject(e)
+  if(parts[0].toUpperCase() == 'V') {
+    // Don't parse this sentence as it's void.
+    throw new Error('Not parsing sentence for it\'s void (LORAN-C blink/SNR warning)')
   }
+
+  if(parts[1].toUpperCase() == 'V') {
+    throw new Error('Not parsing sentence for it\'s void (LORAN-C cycle warning)')
+  }
+
+  const xte = utils.transform(parts[2], (parts[4].toUpperCase() === 'N' ? 'nm' : 'km'), 'm')
+
+  const currentRoute = {
+    source: utils.source(id),
+    timestamp: utils.timestamp(),
+    steer: (parts[3].toUpperCase() == 'R' ? 'right' : 'left'),
+    bearingActual: utils.transform(utils.float(parts[10]), 'deg', 'rad'),
+    bearingDirect: utils.transform(utils.float(parts[7]), 'deg', 'rad'),
+    courseRequired: utils.transform(utils.float(parts[12]), 'deg', 'rad'),
+    waypoint: {
+      next: parts[9],
+      xte: xte
+    }
+  }
+
+  throw new Error('@FIXME: APB hook needs to be rewritten to fit latest version of SK')
 }

--- a/hooks/DBT.js
+++ b/hooks/DBT.js
@@ -2,20 +2,20 @@
 
 /**
  * Copyright 2016 Signal K and Fabian Tollenaar <fabian@signalk.org>.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 const debug = require('debug')('signalk-parser-nmea0183/DBT')
 const utils = require('@signalk/nmea0183-utilities')
 
@@ -37,31 +37,26 @@ Field Number:
 */
 
 module.exports = function (parser, input) {
-  try {
-    const { id, sentence, parts, tags } = input
+  const { id, sentence, parts, tags } = input
 
-    if ((typeof parts[2] !== 'string' && typeof parts[2] !== 'number') || (typeof parts[2] === 'string' && parts[2].trim() === '')) {
-      return Promise.resolve(null)
-    }
-
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: tags.timestamp,
-          values: [
-            {
-              path: 'environment.depth.belowTransducer',
-              value: utils.float(parts[2])
-            }
-          ]
-        }
-      ],
-    }
-    
-    return Promise.resolve({ delta })
-  } catch (e) {
-    debug(`Try/catch failed: ${e.message}`)
-    return Promise.reject(e)
+  if ((typeof parts[2] !== 'string' && typeof parts[2] !== 'number') || (typeof parts[2] === 'string' && parts[2].trim() === '')) {
+    return null
   }
+
+  const delta = {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: [
+          {
+            path: 'environment.depth.belowTransducer',
+            value: utils.float(parts[2])
+          }
+        ]
+      }
+    ],
+  }
+
+  return delta
 }

--- a/hooks/DPT.js
+++ b/hooks/DPT.js
@@ -2,20 +2,20 @@
 
 /**
  * Copyright 2016 Signal K and Fabian Tollenaar <fabian@signalk.org>.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 const debug = require('debug')('signalk-parser-nmea0183/DBT')
 const utils = require('@signalk/nmea0183-utilities')
 
@@ -23,7 +23,7 @@ const utils = require('@signalk/nmea0183-utilities')
 === DPT - Depth of water ===
 ------------------------------------------------------------------------------
 *******0   1   2
-*******|   |   | 
+*******|   |   |
 $--DPT,x.x,x.x*hh<CR><LF>
 ------------------------------------------------------------------------------
 Field Number:
@@ -33,55 +33,50 @@ Field Number:
 */
 
 module.exports = function (parser, input) {
-  try {
-    const { id, sentence, parts, tags } = input
+  const { id, sentence, parts, tags } = input
 
-    if (((typeof parts[0] !== 'string' || parts[0].trim() == '') && typeof parts[0] !== 'number') ||
-        (typeof parts[1] !== 'string' && typeof parts[1] !== 'number')) {
-      return Promise.resolve(null)
-    }
-    var depth = utils.float(parts[0])
-
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: tags.timestamp,
-          values: [
-            {
-              path: 'environment.depth.belowTransducer',
-              value: depth
-            }
-          ]
-        }
-      ],
-    }
-
-    var offset = utils.float(parts[1])
-
-    if ( offset > 0 ) {
-      delta.updates[0].values.push({
-        path: 'environment.depth.surfaceToTransducer',
-        value: offset
-      })
-      delta.updates[0].values.push({
-        path: 'environment.depth.belowSurface',
-        value: depth + offset 
-      })
-    } else if ( offset < 0 ) {
-      delta.updates[0].values.push({
-        path: 'environment.depth.transducerToKeel',
-        value: offset * -1
-      })
-      delta.updates[0].values.push({
-        path: 'environment.depth.belowKeel',
-        value: depth + offset
-      })
-    }
-
-    return Promise.resolve({ delta })
-  } catch (e) {
-    debug(`Try/catch failed: ${e.message}`)
-    return Promise.reject(e)
+  if (((typeof parts[0] !== 'string' || parts[0].trim() == '') && typeof parts[0] !== 'number') ||
+      (typeof parts[1] !== 'string' && typeof parts[1] !== 'number')) {
+    return null
   }
+  var depth = utils.float(parts[0])
+
+  const delta = {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: [
+          {
+            path: 'environment.depth.belowTransducer',
+            value: depth
+          }
+        ]
+      }
+    ],
+  }
+
+  var offset = utils.float(parts[1])
+
+  if ( offset > 0 ) {
+    delta.updates[0].values.push({
+      path: 'environment.depth.surfaceToTransducer',
+      value: offset
+    })
+    delta.updates[0].values.push({
+      path: 'environment.depth.belowSurface',
+      value: depth + offset
+    })
+  } else if ( offset < 0 ) {
+    delta.updates[0].values.push({
+      path: 'environment.depth.transducerToKeel',
+      value: offset * -1
+    })
+    delta.updates[0].values.push({
+      path: 'environment.depth.belowKeel',
+      value: depth + offset
+    })
+  }
+
+  return delta
 }

--- a/hooks/GGA.js
+++ b/hooks/GGA.js
@@ -2,20 +2,20 @@
 
 /**
  * Copyright 2016 Signal K and Fabian Tollenaar <fabian@signalk.org>.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an 'AS IS' BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 const debug = require('debug')('signalk-parser-nmea0183/GGA')
 const utils = require('@signalk/nmea0183-utilities')
 const moment = require('moment-timezone')
@@ -28,7 +28,7 @@ Time, Position and fix related data for a GPS receiver.
         |         |       | |        | | |  |   |   | |   | |   |    |
  $--GGA,hhmmss.ss,llll.ll,a,yyyyy.yy,a,x,xx,x.x,x.x,M,x.x,M,x.x,xxxx*hh<CR><LF>
 ------------------------------------------------------------------------------
-Field Number: 
+Field Number:
 0. Universal Time Coordinated (UTC)
 1. Latitude
 2. N or S (North or South)
@@ -64,105 +64,100 @@ function isEmpty(mixed) {
 }
 
 module.exports = function (parser, input) {
-  try {
-    const { id, sentence, parts, tags } = input
-    
-    const empty = parts.reduce((e, val) => {
-      if (isEmpty(val)) {
-        ++e
-      }
-      return e
-    }, 0)
+  const { id, sentence, parts, tags } = input
 
-    if (empty > 3) {
-      return Promise.resolve(null)
+  const empty = parts.reduce((e, val) => {
+    if (isEmpty(val)) {
+      ++e
     }
+    return e
+  }, 0)
 
-    const time = parts[0].indexOf('.') === -1 ? parts[0] : parts[0].split('.')[0]
-    const timestamp = utils.timestamp(time, moment.tz('UTC').format('DDMMYY'))
-
-    const quality = [
-      'no GPS',
-      'GNSS Fix',
-      'DGNSS fix',
-      'Precise GNSS',
-      'RTK fixed integer',
-      'RTK float',
-      'Estimated (DR) mode',
-      'Manual input',
-      'Simulator mode',
-      'Error'
-    ]
-
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: timestamp,
-          values: [
-            {
-              path: 'navigation.position',
-              value: {
-                longitude: utils.coordinate(parts[3], parts[4]),
-                latitude: utils.coordinate(parts[1], parts[2])
-              }
-            },
-            {
-              path: 'navigation.gnss.methodQuality',
-              value: quality[utils.int(parts[5])]
-            },
-
-            {
-              path: 'navigation.gnss.satellites',
-              value: utils.int(parts[6])
-            },
-
-            {
-              path: 'navigation.gnss.antennaAltitude',
-              value: utils.int(parts[8])
-            },
-
-            {
-              path: 'navigation.gnss.horizontalDilution',
-              value: utils.int(parts[7])
-            },
-
-            {
-              path: 'navigation.gnss.geoidalSeparation',
-              value: utils.int(parts[11])
-            },
-
-            {
-              path: 'navigation.gnss.differentialAge',
-              value: utils.int(parts[12])
-            },
-
-            {
-              path: 'navigation.gnss.differentialReference',
-              value: Number(parts[13])
-            }
-          ]
-        }
-      ],
-    }
-
-    const toRemove = []
-
-    delta.updates[0].values.forEach((update, index) => {
-      if (typeof update.value === 'undefined' || update.value === null || (typeof update.value === 'string' && update.value.trim() === '') || (typeof update.value === 'number' && isNaN(update.value))) {
-        toRemove.push(index)
-      }
-    })
-
-    if (toRemove.length > 0) {
-      toRemove.forEach(index => {
-        delta.updates[0].values.splice(index, 1)
-      })
-    }
-    
-    return Promise.resolve({ delta })
-  } catch (e) {
-    debug(`Try/catch failed: ${e.message}`)
-    return Promise.reject(e)
+  if (empty > 3) {
+    return null
   }
+
+  const time = parts[0].indexOf('.') === -1 ? parts[0] : parts[0].split('.')[0]
+  const timestamp = utils.timestamp(time, moment.tz('UTC').format('DDMMYY'))
+
+  const quality = [
+    'no GPS',
+    'GNSS Fix',
+    'DGNSS fix',
+    'Precise GNSS',
+    'RTK fixed integer',
+    'RTK float',
+    'Estimated (DR) mode',
+    'Manual input',
+    'Simulator mode',
+    'Error'
+  ]
+
+  const delta = {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: timestamp,
+        values: [
+          {
+            path: 'navigation.position',
+            value: {
+              longitude: utils.coordinate(parts[3], parts[4]),
+              latitude: utils.coordinate(parts[1], parts[2])
+            }
+          },
+          {
+            path: 'navigation.gnss.methodQuality',
+            value: quality[utils.int(parts[5])]
+          },
+
+          {
+            path: 'navigation.gnss.satellites',
+            value: utils.int(parts[6])
+          },
+
+          {
+            path: 'navigation.gnss.antennaAltitude',
+            value: utils.int(parts[8])
+          },
+
+          {
+            path: 'navigation.gnss.horizontalDilution',
+            value: utils.int(parts[7])
+          },
+
+          {
+            path: 'navigation.gnss.geoidalSeparation',
+            value: utils.int(parts[11])
+          },
+
+          {
+            path: 'navigation.gnss.differentialAge',
+            value: utils.int(parts[12])
+          },
+
+          {
+            path: 'navigation.gnss.differentialReference',
+            value: Number(parts[13])
+          }
+        ]
+      }
+    ],
+  }
+
+  const toRemove = []
+
+  delta.updates[0].values.forEach((update, index) => {
+    if (typeof update.value === 'undefined' || update.value === null || (typeof update.value === 'string' && update.value.trim() === '') || (typeof update.value === 'number' && isNaN(update.value))) {
+      toRemove.push(index)
+    }
+  })
+
+  if (toRemove.length > 0) {
+    toRemove.forEach(index => {
+      delta.updates[0].values.splice(index, 1)
+    })
+  }
+
+  return delta
 }

--- a/hooks/GLL.js
+++ b/hooks/GLL.js
@@ -2,20 +2,20 @@
 
 /**
  * Copyright 2016 Signal K and Fabian Tollenaar <fabian@signalk.org>.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an 'AS IS' BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 const debug = require('debug')('signalk-parser-nmea0183/GLL')
 const utils = require('@signalk/nmea0183-utilities')
 const moment = require('moment-timezone')
@@ -23,11 +23,11 @@ const moment = require('moment-timezone')
 /*
 === GLL - Geographic Position - Latitude/Longitude ===
 ------------------------------------------------------------------------------
-        0       1 2        3 4         5 6   
-        |       | |        | |         | |   
+        0       1 2        3 4         5 6
+        |       | |        | |         | |
  $--GLL,llll.ll,a,yyyyy.yy,a,hhmmss.ss,a,m,*hh<CR><LF>
 ------------------------------------------------------------------------------
-Field Number: 
+Field Number:
 0. Latitude
 1. N or S (North or South)
 2. Longitude
@@ -42,46 +42,41 @@ function isEmpty(mixed) {
 }
 
 module.exports = function (parser, input) {
-  try {
-    const { id, sentence, parts, tags } = input
+  const { id, sentence, parts, tags } = input
 
-    let valid = parts.reduce((v, part) => {
-      v = !isEmpty(part)
-      return v
-    }, true)
+  let valid = parts.reduce((v, part) => {
+    v = !isEmpty(part)
+    return v
+  }, true)
 
-    if (typeof parts[5] === 'string' && parts[5].toLowerCase() === 'v') {
-      valid = false
-    }
-
-    if (!valid) {
-      return Promise.resolve(null)
-    }
-
-    const time = parts[4].indexOf('.') === -1 ? parts[4] : parts[4].split('.')[0]
-    const timestamp = utils.timestamp(time, moment.tz('UTC').format('DDMMYY'))
-
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: timestamp,
-          values: [
-            {
-              path: 'navigation.position',
-              value: {
-                longitude: utils.coordinate(parts[2], parts[3]),
-                latitude: utils.coordinate(parts[0], parts[1])
-              }
-            },
-          ]
-        }
-      ],
-    }
-    
-    return Promise.resolve({ delta })
-  } catch (e) {
-    debug(`Try/catch failed: ${e.message}`)
-    return Promise.reject(e)
+  if (typeof parts[5] === 'string' && parts[5].toLowerCase() === 'v') {
+    valid = false
   }
+
+  if (!valid) {
+    return null
+  }
+
+  const time = parts[4].indexOf('.') === -1 ? parts[4] : parts[4].split('.')[0]
+  const timestamp = utils.timestamp(time, moment.tz('UTC').format('DDMMYY'))
+
+  const delta = {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: timestamp,
+        values: [
+          {
+            path: 'navigation.position',
+            value: {
+              longitude: utils.coordinate(parts[2], parts[3]),
+              latitude: utils.coordinate(parts[0], parts[1])
+            }
+          },
+        ]
+      }
+    ],
+  }
+
+  return delta
 }

--- a/hooks/HDG.js
+++ b/hooks/HDG.js
@@ -36,39 +36,34 @@ function isEmpty(mixed) {
 }
 
 module.exports = function (parser, input) {
-  try {
-    const { id, sentence, parts, tags } = input
+  const { id, sentence, parts, tags } = input
 
-    const values = []
-    if (!isEmpty(parts[0])) {
-      values.push({
-        path: 'navigation.headingMagnetic',
-        value: utils.transform(utils.float(parts[0]), 'deg', 'rad')
-      })
-    }
-    if (!(isEmpty(parts[3]) || isEmpty(parts[4]))) {
-      values.push({
-        path: 'navigation.magneticVariation',
-        value: utils.transform(utils.float(parts[3]), 'deg', 'rad') * (parts[4] === 'E' ? 1 : -1)
-      })
-    }
-    if (!values.length) {
-      return Promise.resolve(null)
-    }
-
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: tags.timestamp,
-          values
-        }
-      ],
-    }
-
-    return Promise.resolve({ delta })
-  } catch (e) {
-    debug(`Try/catch failed: ${e.message}`)
-    return Promise.reject(e)
+  const values = []
+  if (!isEmpty(parts[0])) {
+    values.push({
+      path: 'navigation.headingMagnetic',
+      value: utils.transform(utils.float(parts[0]), 'deg', 'rad')
+    })
   }
+  if (!(isEmpty(parts[3]) || isEmpty(parts[4]))) {
+    values.push({
+      path: 'navigation.magneticVariation',
+      value: utils.transform(utils.float(parts[3]), 'deg', 'rad') * (parts[4] === 'E' ? 1 : -1)
+    })
+  }
+  if (!values.length) {
+    return null
+  }
+
+  const delta = {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values
+      }
+    ],
+  }
+
+  return delta
 }

--- a/hooks/HDM.js
+++ b/hooks/HDM.js
@@ -2,20 +2,20 @@
 
 /**
  * Copyright 2016 Signal K and Fabian Tollenaar <fabian@signalk.org>.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 const debug = require('debug')('signalk-parser-nmea0183/DBT')
 const utils = require('@signalk/nmea0183-utilities')
 
@@ -33,31 +33,26 @@ const utils = require('@signalk/nmea0183-utilities')
 */
 
 module.exports = function (parser, input) {
-  try {
-    const { id, sentence, parts, tags } = input
+  const { id, sentence, parts, tags } = input
 
-    if ((typeof parts[0] !== 'string' && typeof parts[0] !== 'number') || (typeof parts[0] === 'string' && parts[0].trim() === '')) {
-      return Promise.resolve(null)
-    }
-
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: tags.timestamp,
-          values: [
-            {
-              path: 'navigation.headingMagnetic',
-              value: utils.transform(utils.float(parts[0]), 'deg', 'rad')
-            }
-          ]
-        }
-      ],
-    }
-    
-    return Promise.resolve({ delta })
-  } catch (e) {
-    debug(`Try/catch failed: ${e.message}`)
-    return Promise.reject(e)
+  if ((typeof parts[0] !== 'string' && typeof parts[0] !== 'number') || (typeof parts[0] === 'string' && parts[0].trim() === '')) {
+    return null
   }
+
+  const delta = {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: [
+          {
+            path: 'navigation.headingMagnetic',
+            value: utils.transform(utils.float(parts[0]), 'deg', 'rad')
+          }
+        ]
+      }
+    ],
+  }
+
+  return delta
 }

--- a/hooks/HDT.js
+++ b/hooks/HDT.js
@@ -2,20 +2,20 @@
 
 /**
  * Copyright 2016 Signal K and Fabian Tollenaar <fabian@signalk.org>.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 const debug = require('debug')('signalk-parser-nmea0183/DBT')
 const utils = require('@signalk/nmea0183-utilities')
 
@@ -33,31 +33,26 @@ Field Number:
 */
 
 module.exports = function (parser, input) {
-  try {
-    const { id, sentence, parts, tags } = input
+  const { id, sentence, parts, tags } = input
 
-    if ((typeof parts[0] !== 'string' && typeof parts[0] !== 'number') || (typeof parts[0] === 'string' && parts[0].trim() === '')) {
-      return Promise.resolve(null)
-    }
-
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: tags.timestamp,
-          values: [
-            {
-              path: 'navigation.headingTrue',
-              value: utils.transform(utils.float(parts[0]), 'deg', 'rad')
-            }
-          ]
-        }
-      ],
-    }
-    
-    return Promise.resolve({ delta })
-  } catch (e) {
-    debug(`Try/catch failed: ${e.message}`)
-    return Promise.reject(e)
+  if ((typeof parts[0] !== 'string' && typeof parts[0] !== 'number') || (typeof parts[0] === 'string' && parts[0].trim() === '')) {
+    return null
   }
+
+  const delta = {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: [
+          {
+            path: 'navigation.headingTrue',
+            value: utils.transform(utils.float(parts[0]), 'deg', 'rad')
+          }
+        ]
+      }
+    ],
+  }
+
+  return delta
 }

--- a/hooks/KEP.js
+++ b/hooks/KEP.js
@@ -70,106 +70,96 @@ function isEmpty(mixed) {
 }
 
 module.exports = function(parser, input) {
-  try {
-    const { id, sentence, parts, tags } = input
+  const { id, sentence, parts, tags } = input
 
-    var delta
-    //PNKEP,01
-
-    if (parts[0] === "01") {
-      if (parts[1] === "" && parts[3] === "") {
-        return Promise.resolve(null)
-      }
-
-      let targetspeed = 0.0
-
-      if (utils.float(parts[3]) > 0 && String(parts[4]).toUpperCase() === "K") {
-        targetspeed = utils.transform(utils.float(parts[3]), "kph", "ms")
-      }
-
-      if (utils.float(parts[1]) > 0 && String(parts[2]).toUpperCase() === "N") {
-        targetspeed = utils.transform(utils.float(parts[1]), "knots", "ms")
-      }
-
-      delta = {
-        updates: [
-          {
-            source: tags.source,
-            timestamp: tags.timestamp,
-            values: [
-              {
-                path: "performance.targetSpeed",
-                value: targetspeed
-              }
-            ]
-          }
-        ]
-      }
+  var delta
+  //PNKEP,01
+  if (parts[0] === "01") {
+    if (parts[1] === "" && parts[3] === "") {
+      return null
     }
 
-    // PNKEP,02
+    let targetspeed = 0.0
 
-    if (parts[0] === "02") {
-      if (parts[1] === "") {
-        return Promise.resolve(null)
-      }
-
-      let nxtcourse = 0.0
-
-      if (utils.float(parts[1]) > 0) {
-        nxtcourse = utils.transform(utils.float(parts[1]), "deg", "rad")
-      }
-
-      delta = {
-        updates: [
-          {
-            source: tags.source,
-            timestamp: tags.timestamp,
-            values: [
-              {
-                path: "performance.tackMagnetic",
-                value: nxtcourse
-              }
-            ]
-          }
-        ]
-      }
+    if (utils.float(parts[3]) > 0 && String(parts[4]).toUpperCase() === "K") {
+      targetspeed = utils.transform(utils.float(parts[3]), "kph", "ms")
     }
 
-    // PNKEP,03
-
-    if (parts[0] === "03") {
-      if (parts[1] === "") {
-        return Promise.resolve(null)
-      }
-
-      let optcourse = 0.0
-
-      if (utils.float(parts[1]) > 0) {
-        optcourse = utils.transform(utils.float(parts[1]), "deg", "rad")
-      }
-
-      delta = {
-        updates: [
-          {
-            source: tags.source,
-            timestamp: tags.timestamp,
-            values: [
-              {
-                path: "performance.targetAngle",
-                value: optcourse
-              }
-            ]
-          }
-        ]
-      }
+    if (utils.float(parts[1]) > 0 && String(parts[2]).toUpperCase() === "N") {
+      targetspeed = utils.transform(utils.float(parts[1]), "knots", "ms")
     }
 
-    return Promise.resolve({
-      delta
-    })
-  } catch (e) {
-    debug(`Try/catch failed: ${e.message}`)
-    return Promise.reject(e)
+    delta = {
+      updates: [
+        {
+          source: tags.source,
+          timestamp: tags.timestamp,
+          values: [
+            {
+              path: "performance.targetSpeed",
+              value: targetspeed
+            }
+          ]
+        }
+      ]
+    }
   }
+
+  // PNKEP,02
+  if (parts[0] === "02") {
+    if (parts[1] === "") {
+      return null
+    }
+
+    let nxtcourse = 0.0
+
+    if (utils.float(parts[1]) > 0) {
+      nxtcourse = utils.transform(utils.float(parts[1]), "deg", "rad")
+    }
+
+    delta = {
+      updates: [
+        {
+          source: tags.source,
+          timestamp: tags.timestamp,
+          values: [
+            {
+              path: "performance.tackMagnetic",
+              value: nxtcourse
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  // PNKEP,03
+  if (parts[0] === "03") {
+    if (parts[1] === "") {
+      return null
+    }
+
+    let optcourse = 0.0
+
+    if (utils.float(parts[1]) > 0) {
+      optcourse = utils.transform(utils.float(parts[1]), "deg", "rad")
+    }
+
+    delta = {
+      updates: [
+        {
+          source: tags.source,
+          timestamp: tags.timestamp,
+          values: [
+            {
+              path: "performance.targetAngle",
+              value: optcourse
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  return delta
 }

--- a/hooks/MTW.js
+++ b/hooks/MTW.js
@@ -35,25 +35,21 @@
 module.exports = function (parser, input) {
   const { id, sentence, parts, tags } = input
 
-  try {
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: tags.timestamp,
-          values: [
-            {
-              path: 'environment.water.temperature',
-              value: utils.transform(utils.float(parts[0]), 'c', 'k')
-              //returns raw value, no transformation done
-            }
-          ]
-        }
-      ],
-    }
-
-    return Promise.resolve({ delta })
-  } catch (e) {
-    return Promise.reject(e)
+  const delta = {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: [
+          {
+            path: 'environment.water.temperature',
+            value: utils.transform(utils.float(parts[0]), 'c', 'k')
+            //returns raw value, no transformation done
+          }
+        ]
+      }
+    ],
   }
+
+  return delta
 }

--- a/hooks/MWV.js
+++ b/hooks/MWV.js
@@ -2,20 +2,20 @@
 
 /**
  * Copyright 2016 Signal K and Fabian Tollenaar <fabian@signalk.org>.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 const debug = require('debug')('signalk-parser-nmea0183/MWV')
 const utils = require('@signalk/nmea0183-utilities')
 
@@ -28,50 +28,45 @@ function convertToWindAngle(angle) {
 }
 
 module.exports = function(parser, input) {
-  try {
-    const { id, sentence, parts, tags } = input
+  const { id, sentence, parts, tags } = input
 
-    if(!parts[4] || parts[4].toUpperCase() !== 'A') {
-      return Promise.resolve(null)
-    }
-
-    let wsu = parts[3].toUpperCase()
-
-    if (wsu === 'K') {
-      wsu = 'kph';
-    } else if (wsu === 'N') {
-      wsu = 'knots';
-    } else {
-      wsu = 'ms';
-    }
-
-    const angle = convertToWindAngle(parts[0])
-    const speed = utils.transform(parts[2], wsu, 'ms')
-    const valueType = parts[1].toUpperCase() == 'R' ? 'Apparent' : 'True';
-    const angleType = parts[1].toUpperCase() == 'R' ? 'Apparent' : 'TrueWater';
-
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: tags.timestamp,
-          values: [
-            {
-              path: 'environment.wind.speed' + valueType,
-              value: speed
-            }, 
-            {
-              path: 'environment.wind.angle' + angleType,
-              value: utils.transform(angle, 'deg', 'rad')
-            }
-          ]
-        }
-      ],
-    }
-
-    return Promise.resolve({ delta })
-  } catch (e) {
-    debug(`Try/catch failed: ${e.message}`)
-    return Promise.reject(e)
+  if(!parts[4] || parts[4].toUpperCase() !== 'A') {
+    return null
   }
+
+  let wsu = parts[3].toUpperCase()
+
+  if (wsu === 'K') {
+    wsu = 'kph';
+  } else if (wsu === 'N') {
+    wsu = 'knots';
+  } else {
+    wsu = 'ms';
+  }
+
+  const angle = convertToWindAngle(parts[0])
+  const speed = utils.transform(parts[2], wsu, 'ms')
+  const valueType = parts[1].toUpperCase() == 'R' ? 'Apparent' : 'True';
+  const angleType = parts[1].toUpperCase() == 'R' ? 'Apparent' : 'TrueWater';
+
+  const delta = {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: [
+          {
+            path: 'environment.wind.speed' + valueType,
+            value: speed
+          },
+          {
+            path: 'environment.wind.angle' + angleType,
+            value: utils.transform(angle, 'deg', 'rad')
+          }
+        ]
+      }
+    ],
+  }
+
+  return delta
 }

--- a/hooks/RMB.js
+++ b/hooks/RMB.js
@@ -53,9 +53,9 @@ module.exports = function (parser, input) {
   latitude = utils.coordinate(parts[5], parts[6])
   longitude = utils.coordinate(parts[7], parts[8])
   if (isNaN(latitude) || isNaN(longitude)) {
-    return Promise.resolve(null)
+    return null
   }
-  
+
   bearing = utils.float(parts[10])
   bearing = (!isNaN(bearing)) ? bearing : 0.0
 
@@ -64,53 +64,49 @@ module.exports = function (parser, input) {
 
   distance = utils.float(parts[9])
   distance = (!isNaN(distance)) ? distance : 0.0
- 
+
   crossTrackError = utils.float(parts[1])
   crossTrackError = (!isNaN(crossTrackError)) ? crossTrackError : 0.0
 
   crossTrackError = parts[2] == 'R' ? crossTrackError : -crossTrackError;
 
-  try {
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: tags.timestamp,
-          values: [
-            {
-              'path': 'navigation.courseRhumbline.nextPoint',
-              'value': {
-                longitude,
-                latitude
-              }
-            },
-
-            {
-              'path': 'navigation.courseRhumbline.nextPoint.bearingTrue',
-              'value': utils.transform(bearing, 'deg', 'rad')
-            },
-
-            {
-              'path': 'navigation.courseRhumbline.nextPoint.velocityMadeGood',
-              'value': utils.transform(vmg, 'knots', 'ms')
-            },
-
-            {
-              'path': 'navigation.courseRhumbline.nextPoint.distance',
-              'value': utils.transform(distance, 'nm', 'km') * 1000
-            },
-
-            {
-              'path': 'navigation.courseRhumbline.crossTrackError',
-              value: utils.transform(crossTrackError, 'nm', 'km') * 1000
+  const delta = {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: [
+          {
+            'path': 'navigation.courseRhumbline.nextPoint',
+            'value': {
+              longitude,
+              latitude
             }
-          ]
-        }
-      ],
-    }
+          },
 
-    return Promise.resolve({ delta })
-  } catch (e) {
-    return Promise.reject(e)
+          {
+            'path': 'navigation.courseRhumbline.nextPoint.bearingTrue',
+            'value': utils.transform(bearing, 'deg', 'rad')
+          },
+
+          {
+            'path': 'navigation.courseRhumbline.nextPoint.velocityMadeGood',
+            'value': utils.transform(vmg, 'knots', 'ms')
+          },
+
+          {
+            'path': 'navigation.courseRhumbline.nextPoint.distance',
+            'value': utils.transform(distance, 'nm', 'km') * 1000
+          },
+
+          {
+            'path': 'navigation.courseRhumbline.crossTrackError',
+            value: utils.transform(crossTrackError, 'nm', 'km') * 1000
+          }
+        ]
+      }
+    ],
   }
+
+  return delta
 }

--- a/hooks/RMC.js
+++ b/hooks/RMC.js
@@ -45,66 +45,62 @@ module.exports = function (parser, input) {
   let track = 0.0
   let variation = 0.0
 
-  try {
-    const timestamp = utils.timestamp(parts[0], parts[8])
-    const age = moment.tz(timestamp, 'UTC').unix()
+  const timestamp = utils.timestamp(parts[0], parts[8])
+  const age = moment.tz(timestamp, 'UTC').unix()
 
-    latitude = utils.coordinate(parts[2], parts[3])
-    longitude = utils.coordinate(parts[4], parts[5])
+  latitude = utils.coordinate(parts[2], parts[3])
+  longitude = utils.coordinate(parts[4], parts[5])
 
-    speed = utils.float(parts[6])
-    speed = (!isNaN(speed) && speed > 0) ? speed : 0.0
+  speed = utils.float(parts[6])
+  speed = (!isNaN(speed) && speed > 0) ? speed : 0.0
 
-    track = utils.float(parts[7])
-    track = (!isNaN(track)) ? track : 0.0
+  track = utils.float(parts[7])
+  track = (!isNaN(track)) ? track : 0.0
 
-    variation = utils.magneticVariaton(parts[9], parts[10])
+  variation = utils.magneticVariaton(parts[9], parts[10])
 
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: timestamp,
-          values: [
-            {
-              path: 'navigation.position',
-              value: {
-                longitude,
-                latitude
-              }
-            },
+  const delta = {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: timestamp,
+        values: [
+          {
+            path: 'navigation.position',
+            value: {
+              longitude,
+              latitude
+            }
+          },
 
-            {
-              path: 'navigation.courseOverGroundTrue',
-              value: utils.transform(track, 'deg', 'rad')
-            },
+          {
+            path: 'navigation.courseOverGroundTrue',
+            value: utils.transform(track, 'deg', 'rad')
+          },
 
-            {
-              path: 'navigation.speedOverGround',
-              value: utils.transform(speed, 'knots', 'ms')
-            },
+          {
+            path: 'navigation.speedOverGround',
+            value: utils.transform(speed, 'knots', 'ms')
+          },
 
-            {
-              path: 'navigation.magneticVariation',
-              value: utils.transform(variation, 'deg', 'rad')
-            },
+          {
+            path: 'navigation.magneticVariation',
+            value: utils.transform(variation, 'deg', 'rad')
+          },
 
-            {
-              path: 'navigation.magneticVariationAgeOfService',
-              value: age
-            },
+          {
+            path: 'navigation.magneticVariationAgeOfService',
+            value: age
+          },
 
-            {
-              path: 'navigation.datetime',
-              value: timestamp,
-            },
-          ]
-        }
-      ],
-    }
-
-    return Promise.resolve({ delta })
-  } catch (e) {
-    return Promise.reject(e)
+          {
+            path: 'navigation.datetime',
+            value: timestamp,
+          },
+        ]
+      }
+    ],
   }
+
+  return delta
 }

--- a/hooks/ROT.js
+++ b/hooks/ROT.js
@@ -36,28 +36,23 @@ module.exports = function (parser, input) {
   const { id, sentence, parts, tags } = input
 
   if (String(parts[1]).toUpperCase() !== 'A') {
-    // Don't parse this sentence as it's void.
-    return Promise.reject(new Error('Not parsing sentence as data is not valid)'))
+    return null
   }
 
-  try {
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: tags.timestamp,
-          values: [
-            {
-              path: 'navigation.rateOfTurn',
-              value: utils.transform(utils.float(parts[0]), 'deg', 'rad') / 60
-            }
-          ]
-        }
-      ],
-    }
-
-    return Promise.resolve({ delta })
-  } catch (e) {
-    return Promise.reject(e)
+  const delta = {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: [
+          {
+            path: 'navigation.rateOfTurn',
+            value: utils.transform(utils.float(parts[0]), 'deg', 'rad') / 60
+          }
+        ]
+      }
+    ],
   }
+
+  return delta
 }

--- a/hooks/RPM.js
+++ b/hooks/RPM.js
@@ -30,25 +30,20 @@
 module.exports = function (parser, input) {
   const { id, sentence, parts, tags } = input
 
-
-  try {
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: tags.timestamp,
-          values: [
-            {
-              path: `propulsion.${(parts[0].toUpperCase() === 'S' ? 'shaft' : 'engine')}_${parts[1]}.revolutions`,
-              value: utils.float(parts[2]) / 60
-            }
-          ]
-        }
-      ],
-    }
-
-    return Promise.resolve({ delta })
-  } catch (e) {
-    return Promise.reject(e)
+  const delta = {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: [
+          {
+            path: `propulsion.${(parts[0].toUpperCase() === 'S' ? 'shaft' : 'engine')}_${parts[1]}.revolutions`,
+            value: utils.float(parts[2]) / 60
+          }
+        ]
+      }
+    ],
   }
+
+  return delta
 }

--- a/hooks/VDM.js
+++ b/hooks/VDM.js
@@ -2,13 +2,13 @@
 
 /**
  * Copyright 2016 Signal K and Fabian Tollenaar <fabian@signalk.org>.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an 'AS IS' BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,172 +49,167 @@ const msgTypeToPrefix = {
 }
 
 module.exports = function (parser, input) {
-  try {
-    const { id, sentence, parts, tags } = input
-    const data = new Decoder(sentence, parser.session)
-    const values = []
+  const { id, sentence, parts, tags } = input
+  const data = new Decoder(sentence, parser.session)
+  const values = []
 
-    if (data.valid === false) {
-      return Promise.resolve(null)
-    }
-
-    if (data.mmsi) {
-      values.push({
-        path: '',
-        value: {
-          mmsi: data.mmsi
-        }
-      })
-    }
-
-    if (data.shipname) {
-      values.push({
-        path: '',
-        value: {
-          name: data.shipname
-        }
-      })
-    }
-
-    if (typeof data.sog != 'undefined') {
-      values.push({
-        path: 'navigation.speedOverGround',
-        value: utils.transform(data.sog, 'knots', 'ms')
-      })
-    }
-
-    if (typeof data.cog != 'undefined') {
-      values.push({
-        path: 'navigation.courseOverGroundTrue',
-        value: utils.transform(data.cog, 'deg', 'rad')
-      })
-    }
-
-    if (typeof data.hdg != 'undefined') {
-      values.push({
-        path: 'navigation.headingTrue',
-        value: utils.transform(data.hdg, 'deg', 'rad')
-      })
-    }
-
-    if (data.lon && data.lat) {
-      values.push({
-        path: 'navigation.position',
-        value: {
-          longitude: data.lon,
-          latitude: data.lat
-        }
-      })
-    }
-
-    if ( data.length ) {
-      values.push({
-        path: 'design.length',
-        value: {overall: data.length}
-      })
-    }
-
-    if ( data.width ) {
-      values.push({
-        path: 'design.beam',
-        value: data.width
-      })
-    }    
-
-    if ( data.draught ) {
-      values.push({
-        path: 'design.draft',
-        value: {current: data.draught}
-      })
-    }
-
-    if ( data.dimA ) {
-      values.push({
-        path: 'sensors.ais.fromBow',
-        value: data.dimA
-      })
-    }
-
-    if ( data.dimD && data.width ) {
-      var fromCenter;
-      if (data.dimD > data.width / 2) {
-        fromCenter = (data.dimD - data.width / 2) * -1
-      } else {
-        fromCenter =  data.width / 2 - data.dimD
-      }
-
-      values.push({
-        path: 'sensors.ais.fromCenter',
-        value: fromCenter
-      })
-    }
-
-    if ( data.navstatus ) {
-      var state = stateMapping[data.navstatus]
-      if ( typeof state !== 'undefined' ) {
-        values.push({
-          path: 'navigation.state',
-          value: state
-        })
-      }        
-    }
-
-    if ( data.destination ) {
-      values.push({
-        path: 'navigation.destination.commonName',
-        value: data.destination
-      })
-    }
-
-    if ( data.callsign ) {
-      values.push({
-        path: '',
-        value: {communication:{ callsignVhf: data.callsign}}
-      })
-    }
-    
-    var contextPrefix =  msgTypeToPrefix[data.aistype] || "vessels."
-
-    if ( data.aidtype ) {
-      contextPrefix = "atons."
-      var atonType = schema.getAtonTypeName(data.aidtype)
-      if ( typeof atonType !== 'undefined' ) {
-        values.push({
-          path: 'atonType',
-          value: { "id": data.aidtype, "name": atonType }
-        })
-      }
-    }
-
-    if ( data.cargo )
-    {
-      var typeName = schema.getAISShipTypeName(data.cargo)
-      if ( typeof typeName !== 'undefined' ) {
-        values.push({
-          path: 'design.aisShipType',
-          value: { "id": data.cargo, "name": typeName }
-        })
-      }
-    }
-    
-    if (values.length === 0) {
-      return Promise.resolve(null)
-    }
-
-    const delta = {
-      context: contextPrefix + `urn:mrn:imo:mmsi:${data.mmsi}`,
-      updates: [
-        {
-          source: tags.source,
-          timestamp: tags.timestamp,
-          values: values
-        }
-      ],
-    }
-
-    return Promise.resolve({ delta })
-  } catch (e) {
-    debug(`Try/catch failed: ${e.message}`)
-    return Promise.reject(e)
+  if (data.valid === false) {
+    return null
   }
+
+  if (data.mmsi) {
+    values.push({
+      path: '',
+      value: {
+        mmsi: data.mmsi
+      }
+    })
+  }
+
+  if (data.shipname) {
+    values.push({
+      path: '',
+      value: {
+        name: data.shipname
+      }
+    })
+  }
+
+  if (typeof data.sog != 'undefined') {
+    values.push({
+      path: 'navigation.speedOverGround',
+      value: utils.transform(data.sog, 'knots', 'ms')
+    })
+  }
+
+  if (typeof data.cog != 'undefined') {
+    values.push({
+      path: 'navigation.courseOverGroundTrue',
+      value: utils.transform(data.cog, 'deg', 'rad')
+    })
+  }
+
+  if (typeof data.hdg != 'undefined') {
+    values.push({
+      path: 'navigation.headingTrue',
+      value: utils.transform(data.hdg, 'deg', 'rad')
+    })
+  }
+
+  if (data.lon && data.lat) {
+    values.push({
+      path: 'navigation.position',
+      value: {
+        longitude: data.lon,
+        latitude: data.lat
+      }
+    })
+  }
+
+  if ( data.length ) {
+    values.push({
+      path: 'design.length',
+      value: {overall: data.length}
+    })
+  }
+
+  if ( data.width ) {
+    values.push({
+      path: 'design.beam',
+      value: data.width
+    })
+  }
+
+  if ( data.draught ) {
+    values.push({
+      path: 'design.draft',
+      value: {current: data.draught}
+    })
+  }
+
+  if ( data.dimA ) {
+    values.push({
+      path: 'sensors.ais.fromBow',
+      value: data.dimA
+    })
+  }
+
+  if ( data.dimD && data.width ) {
+    var fromCenter;
+    if (data.dimD > data.width / 2) {
+      fromCenter = (data.dimD - data.width / 2) * -1
+    } else {
+      fromCenter =  data.width / 2 - data.dimD
+    }
+
+    values.push({
+      path: 'sensors.ais.fromCenter',
+      value: fromCenter
+    })
+  }
+
+  if ( data.navstatus ) {
+    var state = stateMapping[data.navstatus]
+    if ( typeof state !== 'undefined' ) {
+      values.push({
+        path: 'navigation.state',
+        value: state
+      })
+    }
+  }
+
+  if ( data.destination ) {
+    values.push({
+      path: 'navigation.destination.commonName',
+      value: data.destination
+    })
+  }
+
+  if ( data.callsign ) {
+    values.push({
+      path: '',
+      value: {communication:{ callsignVhf: data.callsign}}
+    })
+  }
+
+  var contextPrefix =  msgTypeToPrefix[data.aistype] || "vessels."
+
+  if ( data.aidtype ) {
+    contextPrefix = "atons."
+    var atonType = schema.getAtonTypeName(data.aidtype)
+    if ( typeof atonType !== 'undefined' ) {
+      values.push({
+        path: 'atonType',
+        value: { "id": data.aidtype, "name": atonType }
+      })
+    }
+  }
+
+  if ( data.cargo )
+  {
+    var typeName = schema.getAISShipTypeName(data.cargo)
+    if ( typeof typeName !== 'undefined' ) {
+      values.push({
+        path: 'design.aisShipType',
+        value: { "id": data.cargo, "name": typeName }
+      })
+    }
+  }
+
+  if (values.length === 0) {
+    return null
+  }
+
+  const delta = {
+    context: contextPrefix + `urn:mrn:imo:mmsi:${data.mmsi}`,
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: values
+      }
+    ],
+  }
+
+  return delta
 }

--- a/hooks/VDR.js
+++ b/hooks/VDR.js
@@ -36,26 +36,22 @@ Field Number:
 module.exports = function (parser, input) {
   const { id, sentence, parts, tags } = input
 
-  try {
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: tags.timestamp,
-          values: [{
-            "path": "environment.current",
-            "value": {
-              "setTrue": utils.transform(utils.float(parts[0]),'deg', 'rad'), 
-              "setMagnetic": utils.transform(utils.float(parts[2]),'deg', 'rad'),
-              "drift": utils.transform(utils.float(parts[4]), 'knots', 'ms')
-            }
-          }]
-        }
-      ],
-    }
-
-    return Promise.resolve({ delta })
-  } catch (e) {
-    return Promise.reject(e)
+  const delta = {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: [{
+          "path": "environment.current",
+          "value": {
+            "setTrue": utils.transform(utils.float(parts[0]),'deg', 'rad'),
+            "setMagnetic": utils.transform(utils.float(parts[2]),'deg', 'rad'),
+            "drift": utils.transform(utils.float(parts[4]), 'knots', 'ms')
+          }
+        }]
+      }
+    ],
   }
+
+  return delta
 }

--- a/hooks/VHW.js
+++ b/hooks/VHW.js
@@ -64,19 +64,15 @@ module.exports = function (parser, input) {
 
 
 
-  try {
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: tags.timestamp,
-          values: pathValues
-        }
-      ],
-    }
-
-    return Promise.resolve({ delta })
-  } catch (e) {
-    return Promise.reject(e)
+  const delta = {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: pathValues
+      }
+    ],
   }
+
+  return delta
 }

--- a/hooks/VLW.js
+++ b/hooks/VLW.js
@@ -52,8 +52,7 @@ module.exports = function (parser, input) {
     })
   }
 
-  try {
-    const delta = {
+  return {
       updates: [
         {
           source: tags.source,
@@ -62,9 +61,4 @@ module.exports = function (parser, input) {
         }
       ],
     }
-
-    return Promise.resolve({ delta })
-  } catch (e) {
-    return Promise.reject(e)
-  }
 }

--- a/hooks/VPW.js
+++ b/hooks/VPW.js
@@ -43,26 +43,19 @@ module.exports = function (parser, input) {
   else {
     return null
   }
-  try {
 
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: tags.timestamp,
-          values: [
-            {
-              path: 'performance.velocityMadeGood',
-              value: velocityValue
-            }
-          ]
-        }
-      ],
-    }
-
-
-    return Promise.resolve({ delta })
-  } catch (e) {
-    return Promise.reject(e)
+  return {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: [
+          {
+            path: 'performance.velocityMadeGood',
+            value: velocityValue
+          }
+        ]
+      }
+    ],
   }
 }

--- a/hooks/VTG.js
+++ b/hooks/VTG.js
@@ -44,49 +44,42 @@ function isEmpty(mixed) {
 }
 
 module.exports = function (parser, input) {
-  try {
-    const { id, sentence, parts, tags } = input
+  const { id, sentence, parts, tags } = input
 
-    if (parts[2] === '' && parts[0] === '' && parts[6] === '' && parts[4] === '') {
-      return Promise.resolve(null)
-    }
+  if (parts[2] === '' && parts[0] === '' && parts[6] === '' && parts[4] === '') {
+    return null
+  }
 
-    let speed = 0.0
+  let speed = 0.0
 
-    if (utils.float(parts[6]) > 0 && String(parts[7]).toUpperCase() === 'K') {
-      speed = utils.transform(utils.float(parts[6]), 'kph', 'ms');
-    }
+  if (utils.float(parts[6]) > 0 && String(parts[7]).toUpperCase() === 'K') {
+    speed = utils.transform(utils.float(parts[6]), 'kph', 'ms');
+  }
 
-    if (utils.float(parts[4]) > 0 && String(parts[5]).toUpperCase() === 'N') {
-      speed = utils.transform(utils.float(parts[4]), 'knots', 'ms');
-    }
+  if (utils.float(parts[4]) > 0 && String(parts[5]).toUpperCase() === 'N') {
+    speed = utils.transform(utils.float(parts[4]), 'knots', 'ms');
+  }
 
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: tags.timestamp,
-          values: [
-            {
-              path: 'navigation.courseOverGroundMagnetic',
-              value: utils.transform(utils.float(parts[2]), 'deg', 'rad')
-            },
-            {
-              path: 'navigation.courseOverGroundTrue',
-              value: utils.transform(utils.float(parts[0]), 'deg', 'rad')
-            },
-            {
-              path: 'navigation.speedOverGround',
-              value: speed
-            },
-          ]
-        }
-      ],
-    }
-
-    return Promise.resolve({ delta })
-  } catch (e) {
-    debug(`Try/catch failed: ${e.message}`)
-    return Promise.reject(e)
+  return {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: [
+          {
+            path: 'navigation.courseOverGroundMagnetic',
+            value: utils.transform(utils.float(parts[2]), 'deg', 'rad')
+          },
+          {
+            path: 'navigation.courseOverGroundTrue',
+            value: utils.transform(utils.float(parts[0]), 'deg', 'rad')
+          },
+          {
+            path: 'navigation.speedOverGround',
+            value: speed
+          },
+        ]
+      }
+    ],
   }
 }

--- a/hooks/VWR.js
+++ b/hooks/VWR.js
@@ -42,38 +42,32 @@ module.exports = function (parser, input) {
 
   const empty = parts.reduce((count, part) => { count += (isEmpty(part) ? 1 : 0); return count; }, 0)
   if (empty > 4) {
-    return Promise.resolve(null)
+    return null
   }
 
   var rightPositive = 0;
   if (String(parts[1]).toUpperCase() === 'R') {
     rightPositive = 1;
-  }else if (String(parts[1]).toUpperCase() === 'L') {
+  } else if (String(parts[1]).toUpperCase() === 'L') {
     rightPositive = -1;
   }
 
-  try {
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: tags.timestamp,
-          values: [
-            {
-              path: 'environment.wind.angleApparent',
-              value: utils.transform(utils.float(parts[0])*rightPositive, 'deg', 'rad')
-            },
-            {
-              path: 'environment.wind.speedApparent',
-              value: utils.transform(utils.float(parts[2]), 'knots', 'ms')
-            }
-          ]
-        }
-      ],
-    }
-
-    return Promise.resolve({ delta })
-  } catch (e) {
-    return Promise.reject(e)
+  return {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: [
+          {
+            path: 'environment.wind.angleApparent',
+            value: utils.transform(utils.float(parts[0])*rightPositive, 'deg', 'rad')
+          },
+          {
+            path: 'environment.wind.speedApparent',
+            value: utils.transform(utils.float(parts[2]), 'knots', 'ms')
+          }
+        ]
+      }
+    ],
   }
 }

--- a/hooks/ZDA.js
+++ b/hooks/ZDA.js
@@ -46,67 +46,62 @@ function isEmpty(mixed) {
 }
 
 module.exports = function (parser, input) {
-  try {
-    const { id, sentence, parts, tags } = input
+  const { id, sentence, parts, tags } = input
 
-    const empty = parts.reduce((e, val) => {
-      if (isEmpty(val)) {
-        ++e
-      }
-      return e
-    }, 0)
-
-    if (empty > 3) {
-      return Promise.resolve(null)
+  const empty = parts.reduce((e, val) => {
+    if (isEmpty(val)) {
+      ++e
     }
+    return e
+  }, 0)
 
-    const time = (parts[0] || '')
-    const date =  parts[1] + parts[2] + (parts[3] || '').slice(-2)
-
-    var delta ={}
-    if (time.length >= 6 && date.length === 6 && empty < 3) {
-      const year = parts[3]
-      const month = parts[2]-1
-      const day = parts[1]
-      const hour = (parts[0] || '').substring(0, 2)
-      const minute = (parts[0] || '').substring(2, 4)
-      const second = (parts[0] || '').substring(4, 6)
-      const milliSecond = (parts[0].substring(4) % second)*1000
-      const d = new Date(Date.UTC(year, month, day, hour, minute, second, milliSecond ))
-      const ts = d.toISOString();
-      delta = {
-        updates: [
-          {
-            source: tags.source,
-            timestamp: tags.timestamp,
-            values: [
-              {
-                "path": "navigation.datetime",
-                "value": ts
-              }
-            ]
-          }
-        ],
-      }
-    }
-
-    const toRemove = []
-
-    delta.updates[0].values.forEach((update, index) => {
-      if (typeof update.value === 'undefined' || update.value === null || (typeof update.value === 'string' && update.value.trim() === '') || (typeof update.value !== 'string' && isNaN(update.value))) {
-        toRemove.push(index)
-      }
-    })
-
-    if (toRemove.length > 0) {
-      toRemove.forEach(index => {
-        delta.updates[0].values.splice(index, 1)
-      })
-    }
-
-    return Promise.resolve({ delta })
-  } catch (e) {
-    debug(`Try/catch failed: ${e.message}`)
-    return Promise.reject(e)
+  if (empty > 3) {
+    return null
   }
+
+  const time = (parts[0] || '')
+  const date =  parts[1] + parts[2] + (parts[3] || '').slice(-2)
+
+  var delta ={}
+  if (time.length >= 6 && date.length === 6 && empty < 3) {
+    const year = parts[3]
+    const month = parts[2]-1
+    const day = parts[1]
+    const hour = (parts[0] || '').substring(0, 2)
+    const minute = (parts[0] || '').substring(2, 4)
+    const second = (parts[0] || '').substring(4, 6)
+    const milliSecond = (parts[0].substring(4) % second)*1000
+    const d = new Date(Date.UTC(year, month, day, hour, minute, second, milliSecond ))
+    const ts = d.toISOString();
+    delta = {
+      updates: [
+        {
+          source: tags.source,
+          timestamp: tags.timestamp,
+          values: [
+            {
+              "path": "navigation.datetime",
+              "value": ts
+            }
+          ]
+        }
+      ],
+    }
+  }
+
+  const toRemove = []
+
+  delta.updates[0].values.forEach((update, index) => {
+    if (typeof update.value === 'undefined' || update.value === null || (typeof update.value === 'string' && update.value.trim() === '') || (typeof update.value !== 'string' && isNaN(update.value))) {
+      toRemove.push(index)
+    }
+  })
+
+  if (toRemove.length > 0) {
+    toRemove.forEach(index => {
+      delta.updates[0].values.splice(index, 1)
+    })
+  }
+
+  return delta
 }

--- a/hooks/seatalk/0x84.js
+++ b/hooks/seatalk/0x84.js
@@ -52,6 +52,10 @@ module.exports = function (parser, input) {
   const { id, sentence, parts, tags } = input
   var mode
 
+  if (parts.length != 9) {
+    return null
+  }
+
   var U = parseInt(parts[1].charAt(0), 16)
   var VW = parseInt(parts[2], 16)
   var V = parseInt(parts[2].charAt(0), 16)
@@ -61,6 +65,12 @@ module.exports = function (parser, input) {
   var RR = parseInt(parts[6], 16)
   var SS = parseInt(parts[7], 16)
   var TT = parseInt(parts[8], 16)
+
+  const inputs = [U, VW, V, XY, Z, M, RR, SS, TT]
+  if (! inputs.every((x) => !isNaN(x))) {
+    return null
+  }
+
   var compassHeading = (U & 0x3) * 90 + (VW & 0x3F) * 2 + (U & 0xC ? (U & 0xC == 0xC ? 2 : 1) : 0)
   var apCourse = ((V & 0xC) >> 2) * 90 + XY / 2
   /*Positive to right*/
@@ -112,21 +122,13 @@ module.exports = function (parser, input) {
     })
   }
 
-  try {
-
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: tags.timestamp,
-          values: pathValues
-        }
-      ],
-    }
-
-
-    return Promise.resolve({ delta })
-  } catch (e) {
-    return Promise.reject(e)
+  return {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: pathValues
+      }
+    ],
   }
 }

--- a/hooks/seatalk/0x9C.js
+++ b/hooks/seatalk/0x9C.js
@@ -39,6 +39,9 @@ module.exports = function (parser, input) {
   var VW = parseInt(parts[2], 16)
   var RR = parseInt(parts[3], 16)
 
+  if (Number.isNaN(U) || Number.isNaN(VW) || Number.isNaN(RR)) {
+    return null
+  }
   var compassHeading = (U & 0x3) * 90 + (VW & 0x3F) * 2 + (U & 0xC ? (U & 0xC == 0xC ? 2 : 1) : 0);
   var rudderPos = RR;
   if(rudderPos > 127) {
@@ -59,27 +62,13 @@ module.exports = function (parser, input) {
     })
   }
 
-  /*
-  if(pathValues.length < 1){
-    return Promise.resolve(null)
-  }
-  */
-
-  try {
-
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: tags.timestamp,
-          values: pathValues
-        }
-      ]
-    }
-
-
-    return Promise.resolve({ delta })
-  } catch (e) {
-    return Promise.reject(e)
+  return {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: pathValues
+      }
+    ]
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,9 +16,7 @@
  * limitations under the License.
  */
 
-const debug = require('debug')('signalk-parser-nmea0183')
 const EventEmitter = require('events')
-const stream = require('stream')
 const isObject = require('./types').isObject
 const parseSentence = require('./parse')
 const pkg = require('../package.json')
@@ -40,18 +38,22 @@ class Parser extends EventEmitter {
       this.emit('nmea0183', sentence.trim())
     }
 
-    return parseSentence(this, sentence, this.options)
-      .then(result => {
-        if (typeof result === 'object' && result !== null) {
-          // this.emit('signalk:full', result.full || {})
-          this.emit('signalk:delta', result.delta || {})
-        }
-
-        return result
-      })
-      .catch(e => {
-        this.emit('error', e)
-      })
+    try {
+      var result = parseSentence(this, sentence, this.options)
+      if (typeof result === 'object' && result !== null) {
+        this.emit('signalk:delta', result || {})
+      }
+      // Return value kept for backwards compatibility.
+      if (result !== null) {
+        return Promise.resolve({ delta: result })
+      }
+      else {
+        return Promise.resolve(null)
+      }
+    }
+    catch(e) {
+      return Promise.reject(e)
+    }
   }
 }
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -44,7 +44,9 @@ module.exports = function parseSentence(emitter, sentence, options) {
 
   if (valid === false) {
     emitter.emit('warning', { message: `Sentence "${sentence.trim()}" is invalid` })
-    return Promise.reject(new Error(`Sentence "${sentence.trim()}" is invalid`))
+    // FIXME: Do we really want an exception (or Promise.reject) here?
+    // I think returning null would be more coherent.
+    throw new Error(`Sentence "${sentence.trim()}" is invalid`)
   }
 
   if ( sentence.charCodeAt(sentence.length-1) == 10 ) {
@@ -67,20 +69,14 @@ module.exports = function parseSentence(emitter, sentence, options) {
 
   if (!hook) {
     emitter.emit('warning', { message: `No hook found for "${sentence.trim()}"` })
-    return Promise.resolve(null)
+    return null
   }
 
-  const parser = hook(emitter, {
+  const result = hook(emitter, {
     id,
     sentence,
     parts: split,
     tags
   })
-
-  if (parser === null || typeof parser !== 'object' || typeof parser.then !== 'function') {
-    // debug(`Parser is not a promise... (${typeof parser})`, parser)
-    return Promise.resolve(parser)
-  }
-
-  return parser.then(data => transformSource(data, id, talker))
+  return transformSource(result, id, talker)
 }

--- a/lib/transformSource.js
+++ b/lib/transformSource.js
@@ -2,26 +2,22 @@
 
 /**
  * transformSource.js
- * 
- * Checks if the "source" key in each update is an object, 
+ *
+ * Checks if the "source" key in each update is an object,
  * creates the object if it's a string.
  *
- * @param "data": object with a key called "delta"
+ * @param "data": signalk delta object
  */
 module.exports = function transformSource(data, sentence, talker) {
   if (typeof data !== 'object' || data === null) {
     return data
   }
 
-  if (typeof data.delta !== 'object' || data.delta === null) {
+  if (!Array.isArray(data.updates)) {
     return data
   }
 
-  if (!Array.isArray(data.delta.updates)) {
-    return data
-  }
-
-  data.delta.updates = data.delta.updates.map(update => {
+  data.updates = data.updates.map(update => {
     if (typeof update.source === 'object' && update.source !== null) {
       return update
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
     "async": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
       "requires": {
         "lodash": "^4.14.0"
       },
@@ -318,7 +318,7 @@
     "jison": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/jison/-/jison-0.4.18.tgz",
-      "integrity": "sha512-FKkCiJvozgC7VTHhMJ00a0/IApSxhlGsFIshLW6trWJ8ONX2TQJBBz6DlcO1Gffy4w9LT+uL+PA+CVnUSJMF7w==",
+      "integrity": "sha1-xopqVL/nAo+kC8/GzIu9ntKR9QI=",
       "requires": {
         "JSONSelect": "0.4.0",
         "cjson": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalk/nmea0183-signalk",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A node.js/javascript parser for NMEA0183 sentences. Sentences are parsed to Signal K format.",
   "main": "index.js",
   "scripts": {

--- a/test/ALK.js
+++ b/test/ALK.js
@@ -119,16 +119,21 @@ describe('ALK', done => {
     parser.parse(heading_nineC)
   })
 
-/*
-  it('Doesn\'t choke on empty sentences', done => {
-    const parser = new Parser
-    parser
-    .parse('$STALK,9C,,,*3B')
-    .then(result => {
-      should.equal(result, null)
+  it('Doesn\'t choke on empty 0x9C sentences', () => {
+    const parser = new Parser()
+    parser.on('signalk:delta', delta => {
+      should.equal(delta, null)
       done()
     })
-    .catch(e => done(e))
+    parser.parse('$STALK,9C,,,*3B').catch(e => done(e))
   })
-*/
+
+  it('Doesn\'t choke on empty 0x84 sentences', () => {
+    const parser = new Parser()
+    parser.on('signalk:delta', delta => {
+      should.equal(delta, null)
+      done()
+    })
+    parser.parse('$STALK,84,,,,,,,,*61').catch(e => done(e))
+  })
 })

--- a/test/APB.js
+++ b/test/APB.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2016 Signal K and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict'
+
+const Parser = require('../lib')
+const chai = require('chai')
+const should = require('chai').Should()
+
+chai.Should()
+chai.use(require('chai-things'))
+
+describe('APB', done => {
+  it('Doesn\'t parse APB sentences', done => {
+    new Parser()
+    .parse('$GPAPB,A,A,0.10,R,N,V,V,011,M,DEST,011,M,011,M*3C')
+    .then(result => {
+      should.equal(result, null)
+      done()
+    })
+    .catch(e => {
+      should.equal(e.message, "@FIXME: APB hook needs to be rewritten to fit latest version of SK")
+      done()
+    })
+  })
+
+})

--- a/test/GGA.js
+++ b/test/GGA.js
@@ -26,7 +26,6 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 const toFull = require('./toFull')
 
 describe('GGA', () => {
-
   it('Converts OK using individual parser', done => {
     const parser = new Parser
 


### PR DESCRIPTION
New version of the PR to remove promises (internally only for now):
 - first commit adds a test for APB sentences (they always throw an error). This was helpful to make sure I did not break error handling before/after the other commit.
 - second commit is the big change, it removes try/catch and promises from all the hooks and replaces them by one try/catch in `index.js`'s `Parser::parse()`.

The tests have not been touched (except to re-enable one that was disabled) so it should be a lot easier to review this PR and make sure it does not change more than what it pretends to change. 

I will add more PR to update the API and make sure we do not return a promise to the caller and always handler errors in the same way. The other PR will be more complicated but easier to review since it will not include all the hooks changes we have here.