### PR TITLE
feature: add an option to ignore missing checksums

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,8 +25,13 @@ const pkg = require('../package.json')
 class Parser {
   constructor (opts) {
     this.options = (typeof opts === 'object' && opts !== null) ? opts : {}
+
+    // Default values
     if (!Object.keys(this.options).includes('validateChecksum')) {
       this.options.validateChecksum = true
+    }
+    if (!Object.keys(this.options).includes('requireChecksum')) {
+      this.options.requireChecksum = true
     }
     this.session = {}
 
@@ -49,7 +54,7 @@ class Parser {
       tags.timestamp = new Date().toISOString()
     }
 
-    let valid = utils.valid(sentence, this.options.validateChecksum)
+    let valid = utils.valid(sentence, this.options.validateChecksum, this.options.requireChecksum)
     if (valid === false) {
       throw new Error(`Sentence "${sentence.trim()}" is invalid`)
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalk/nmea0183-signalk",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "A node.js/javascript parser for NMEA0183 sentences. Sentences are parsed to Signal K format.",
   "main": "index.js",
   "scripts": {
@@ -23,7 +23,7 @@
   "author": "Fabian Tollenaar <fabian@signalk.org> (http://signalk.org)",
   "license": "Apache-2.0",
   "dependencies": {
-    "@signalk/nmea0183-utilities": "^0.6.0",
+    "@signalk/nmea0183-utilities": "^0.6.1",
     "@signalk/signalk-schema": "1.0.3",
     "ggencoder": "^1.0.2",
     "moment-timezone": "^0.5.21",

--- a/test/invalid_checksum.js
+++ b/test/invalid_checksum.js
@@ -21,11 +21,37 @@ const chai = require('chai')
 const should = chai.Should()
 chai.use(require('chai-things'))
 
-const nmeaLine = '$GPROT,35.6,A*FF'
+const nmeaLineInvalidChecksum = '$GPROT,35.6,A*FF'
+const nmeaLineWithoutChecksum = '$GPROT,35.6,A*'
 
 describe('Invalid checksum', () => {
-  it('throws exception on invalid checksum', () => {
-    should.Throw(() => { new Parser().parse(nmeaLine) },
+  it('by default throws exception on invalid checksum', () => {
+    should.Throw(() => { new Parser().parse(nmeaLineInvalidChecksum) },
+      /is invalid/)
+  })
+
+  it('by default throws exception on line without a checksum', () => {
+    should.Throw(() => { new Parser().parse(nmeaLineWithoutChecksum) },
+      /is invalid/)
+  })
+
+  it('with option requireChecksum==false, do not throw on missing checkum', () => {
+    should.not.Throw(() => { new Parser({ requireChecksum: false }).parse(nmeaLineWithoutChecksum) },
+      /is invalid/)
+  })
+
+  it('with options requireChecksum==false, should still throw on invalid checkum', () => {
+    should.Throw(() => { new Parser({ requireChecksum: false }).parse(nmeaLineInvalidChecksum) },
+      /is invalid/)
+  })
+
+  it('with option validateChecksum==false, do not throw on invalid checkum', () => {
+    should.not.Throw(() => { new Parser({ validateChecksum: false }).parse(nmeaLineInvalidChecksum) },
+      /is invalid/)
+  })
+
+  it('with option validateChecksum==false, do not throw on missing checkum', () => {
+    should.not.Throw(() => { new Parser({ validateChecksum: false }).parse(nmeaLineWithoutChecksum) },
       /is invalid/)
   })
 })


### PR DESCRIPTION
This does not change the default behaviour: missing checksums will be
treated as invalid checksums.

However, with this new option it's possible to accept missing checksums,
without accepting sentences that have invalid checksums.

Requires: https://github.com/SignalK/nmea0183-utilities/pull/10/files