### PR TITLE
Implement hooks for various sentences related to autopilot operation

### DIFF
--- a/hooks/BOD.js
+++ b/hooks/BOD.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2019 Signal K and Fabian Tollenaar <fabian@decipher.industries>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const debug = require('debug')('signalk-parser-nmea0183/APB')
+const utils = require('@signalk/nmea0183-utilities')
+
+/**
+ * $GPBOD,045.,T,023.,M,DEST,START*01
+ *
+ * Bearing - origin to destination waypoint (BOD)
+ *
+ * 0) 045.       bearing 045 True from "START" to "DEST"
+ * 1) T,           True
+ * 2) 023.         bearing 023 Magnetic from "START" to "DEST"
+ * 3) M            Magnetic
+ * 4) DEST         destination waypoint ID
+ * 5) START        origin waypoint ID
+**/
+
+module.exports = function BODHook (input) {
+  const { id, sentence, parts, tags } = input
+  const upper = (str) => str.trim().toUpperCase()
+
+  debug(`[BODHook] decoding sentence ${id} => ${sentence}`)
+
+  if (upper(parts[0]) === '' || upper(parts[1]) === '' || upper(parts[2]) === '' || upper(parts[3]) === '' || upper(parts[4]) === '') {
+    return null
+  }
+
+  const bearingOriginToDestination = {}
+
+  bearingOriginToDestination[upper(parts[1]) === 'T' ? 'True' : 'Magnetic'] = utils.transform(parts[0], 'deg', 'rad')
+  bearingOriginToDestination[upper(parts[3]) === 'T' ? 'True' : 'Magnetic'] = utils.transform(parts[2], 'deg', 'rad')
+  const destinationWaypointID = parts[4].trim()
+  const originWaypointID = parts[5].trim()
+
+  return {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: [
+          {
+            path: 'navigation.courseRhumbline.bearingTrackTrue',
+            value: bearingOriginToDestination.True || null
+          },
+          {
+            path: 'navigation.courseRhumbline.bearingTrackMagnetic',
+            value: bearingOriginToDestination.Magnetic || null
+          },
+          {
+            path: 'navigation.courseRhumbline.nextPoint.ID',
+            value: destinationWaypointID
+          },
+          {
+            path: 'navigation.courseRhumbline.previousPoint.ID',
+            value: originWaypointID
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/BWC.js
+++ b/hooks/BWC.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2019 Signal K and Fabian Tollenaar <fabian@decipher.industries>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const debug = require('debug')('signalk-parser-nmea0183/APB')
+const utils = require('@signalk/nmea0183-utilities')
+
+/**
+ * $GPBWC,225444,4917.24,N,12309.57,W,051.9,T,031.6,M,001.3,N,004*29
+ *
+ * Bearing and distance to waypoint - great circle
+ *
+ * 0)     225444        UTC time of fix 22:54:44
+ * 1,2)   4917.24,N     Latitude of waypoint
+ * 3,4)   12309.57,W    Longitude of waypoint
+ * 5,6)   051.9,T       Bearing to waypoint, degrees true
+ * 7,8)   031.6,M       Bearing to waypoint, degrees magnetic
+ * 9,10)  001.3,N       Distance to waypoint, Nautical miles
+ * 11)    004           Waypoint ID
+**/
+
+module.exports = function BWCHook (input) {
+  const { id, sentence, parts, tags } = input
+  const upper = (str) => str.trim().toUpperCase()
+
+  debug(`[BWCHook] decoding sentence ${id} => ${sentence}`)
+
+  if (upper(parts[0]) === '' || upper(parts[1]) === '' || upper(parts[2]) === '' || upper(parts[3]) === '' || upper(parts[4]) === '') {
+    return null
+  }
+
+  const timestamp = utils.timestamp(parts[0])
+  const latitude = utils.coordinate(parts[1], parts[2])
+  const longitude = utils.coordinate(parts[3], parts[4])
+  const distance = utils.transform(parts[9], (upper(parts[10]) === 'N' ? 'nm' : 'km'), 'm')
+
+  const bearingToWaypoint = {}
+  bearingToWaypoint[upper(parts[6]) === 'T' ? 'True' : 'Magnetic'] = utils.transform(parts[5], 'deg', 'rad')
+  bearingToWaypoint[upper(parts[8]) === 'T' ? 'True' : 'Magnetic'] = utils.transform(parts[7], 'deg', 'rad')
+
+  return {
+    updates: [
+      {
+        timestamp,
+        source: tags.source,
+        values: [
+          {
+            path: 'navigation.courseGreatCircle.bearingTrackTrue',
+            value: bearingToWaypoint.True || null
+          },
+          {
+            path: 'navigation.courseGreatCircle.bearingTrackMagnetic',
+            value: bearingToWaypoint.Magnetic || null
+          },
+          {
+            path: 'navigation.courseGreatCircle.nextPoint.distance',
+            value: distance
+          },
+          {
+            path: 'navigation.courseGreatCircle.nextPoint.position',
+            value: {
+              longitude,
+              latitude
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/BWR.js
+++ b/hooks/BWR.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2019 Signal K and Fabian Tollenaar <fabian@decipher.industries>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const debug = require('debug')('signalk-parser-nmea0183/APB')
+const utils = require('@signalk/nmea0183-utilities')
+
+/**
+ * $GPBWR,225444,4917.24,N,12309.57,W,051.9,T,031.6,M,001.3,N,004*38
+ *
+ * Bearing and distance to waypoint - rhumb line
+ *
+ * 0)     225444        UTC time of fix 22:54:44
+ * 1,2)   4917.24,N     Latitude of waypoint
+ * 3,4)   12309.57,W    Longitude of waypoint
+ * 5,6)   051.9,T       Bearing to waypoint, degrees true
+ * 7,8)   031.6,M       Bearing to waypoint, degrees magnetic
+ * 9,10)  001.3,N       Distance to waypoint, Nautical miles
+ * 11)    004           Waypoint ID
+**/
+
+module.exports = function BWRHook (input) {
+  const { id, sentence, parts, tags } = input
+  const upper = (str) => str.trim().toUpperCase()
+
+  debug(`[BWRHook] decoding sentence ${id} => ${sentence}`)
+
+  if (upper(parts[0]) === '' || upper(parts[1]) === '' || upper(parts[2]) === '' || upper(parts[3]) === '' || upper(parts[4]) === '') {
+    return null
+  }
+
+  const timestamp = utils.timestamp(parts[0])
+  const latitude = utils.coordinate(parts[1], parts[2])
+  const longitude = utils.coordinate(parts[3], parts[4])
+  const distance = utils.transform(parts[9], (upper(parts[10]) === 'N' ? 'nm' : 'km'), 'm')
+
+  const bearingToWaypoint = {}
+  bearingToWaypoint[upper(parts[6]) === 'T' ? 'True' : 'Magnetic'] = utils.transform(parts[5], 'deg', 'rad')
+  bearingToWaypoint[upper(parts[8]) === 'T' ? 'True' : 'Magnetic'] = utils.transform(parts[7], 'deg', 'rad')
+
+  return {
+    updates: [
+      {
+        timestamp,
+        source: tags.source,
+        values: [
+          {
+            path: 'navigation.courseRhumbline.bearingTrackTrue',
+            value: bearingToWaypoint.True || null
+          },
+          {
+            path: 'navigation.courseRhumbline.bearingTrackMagnetic',
+            value: bearingToWaypoint.Magnetic || null
+          },
+          {
+            path: 'navigation.courseRhumbline.nextPoint.distance',
+            value: distance
+          },
+          {
+            path: 'navigation.courseRhumbline.nextPoint.position',
+            value: {
+              longitude,
+              latitude
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/HSC.js
+++ b/hooks/HSC.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2019 Signal K and Fabian Tollenaar <fabian@decipher.industries>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const debug = require('debug')('signalk-parser-nmea0183/APB')
+const utils = require('@signalk/nmea0183-utilities')
+
+/**
+ * $FTHSC,40.12,T,39.11,M*5E
+ *
+ * Heading Steering Command
+ *
+ * 0) 40.12         Heading to steer, degrees true
+ * 1) T             True
+ * 2) 39.11         Heading to steer, degrees magnetic
+ * 3) M             Magnetic
+**/
+
+module.exports = function HSCHook (input) {
+  const { id, sentence, parts, tags } = input
+  const upper = (str) => str.trim().toUpperCase()
+
+  debug(`[HSCHook] decoding sentence ${id} => ${sentence}`)
+
+  if (upper(parts[1]) === '' || upper(parts[3]) === '' || upper(parts[0]) === '' || upper(parts[2]) === '') {
+    return null
+  }
+
+  const headingToSteer = {}
+  headingToSteer[upper(parts[1]) === 'T' ? 'True' : 'Magnetic'] = utils.transform(parts[0], 'deg', 'rad')
+  headingToSteer[upper(parts[3]) === 'T' ? 'True' : 'Magnetic'] = utils.transform(parts[2], 'deg', 'rad')
+
+  return {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: [
+          {
+            path: 'steering.autopilot.target.headingTrue',
+            value: headingToSteer.True || null
+          },
+          {
+            path: 'steering.autopilot.target.headingMagnetic',
+            value: headingToSteer.Magnetic || null
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/XTE.js
+++ b/hooks/XTE.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2019 Signal K and Fabian Tollenaar <fabian@decipher.industries>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const debug = require('debug')('signalk-parser-nmea0183/APB')
+const utils = require('@signalk/nmea0183-utilities')
+
+/**
+ *        0 1 2   3 4
+ *        | | |   | |
+ * $--XTE,A,A,x.x,a,N,*hh
+ *
+ * 0) Status   V = LORAN-C blink or SNR warning
+ *             A = general warning flag or other navigation systems when a reliable fix is not available
+ *
+ * 1) Status   V = Loran-C cycle lock warning flag
+ *             A = OK or not used
+ *
+ * 2) Cross track error magnitude
+ * 3) Direction to steer, L or R
+ * 4) Cross track units. N = Nautical Miles
+**/
+
+module.exports = function XTEHook (input) {
+  const { id, sentence, parts, tags } = input
+
+  debug(`[XTEHook] decoding sentence ${id} => ${sentence}`)
+
+  if (parts[0].trim().toUpperCase() === 'V') {
+    // Don't parse this sentence as it's void.
+    throw new Error('Not parsing sentence for it\'s void (LORAN-C blink/SNR warning)')
+  }
+
+  if (parts[1].trim().toUpperCase() === 'V') {
+    throw new Error('Not parsing sentence for it\'s void (LORAN-C cycle warning)')
+  }
+
+  if (parts[2].trim() === '' && parts[3].trim() === '') {
+    return null
+  }
+
+  const direction = parts[3].trim().toUpperCase() === 'L' ? 1 : -1
+  const value = direction * utils.transform(parts[2], (parts[4].trim().toUpperCase() === 'N' ? 'nm' : 'km'), 'm')
+  const path = 'navigation.courseRhumbline.crossTrackError'
+
+  return {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: [
+          {
+            path,
+            value
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/index.js
+++ b/hooks/index.js
@@ -29,5 +29,10 @@ module.exports = {
   'VPW': require('./VPW.js'),
   'VTG': require('./VTG.js'),
   'VWR': require('./VWR.js'),
-  'ZDA': require('./ZDA.js')
+  'ZDA': require('./ZDA.js'),
+  'XTE': require('./XTE.js'),
+  'BOD': require('./BOD.js'),
+  'BWC': require('./BWC.js'),
+  'BWR': require('./BWR.js'),
+  'HSC': require('./HSC.js')
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,8 +36,9 @@ class Parser {
     this.license = pkg.license
   }
 
-  parse(sentence) {
+  parse (sentence) {
     let tags = getTagBlock(sentence)
+
     if (tags !== false) {
       sentence = tags.sentence
       tags = tags.tags
@@ -50,22 +51,26 @@ class Parser {
     }
 
     let valid = utils.valid(sentence, this.options.validateChecksum)
+    
     if (valid === false) {
       throw new Error(`Sentence "${sentence.trim()}" is invalid`)
     }
 
-    if (sentence.charCodeAt(sentence.length-1) == 10 ) {
-      //in case there's a newline
-      sentence = sentence.substr(0, sentence.length-1)
+    if (sentence.charCodeAt(sentence.length - 1) === 10) {
+      // in case there's a newline
+      sentence = sentence.substr(0, sentence.length - 1)
     }
 
     const data = sentence.split('*')[0]
     const dataParts = data.split(',')
-    let id, talker, internalId = ''
-    if (dataParts[0].charAt(1).toUpperCase() === 'P'){ // proprietary sentence
-      id = dataParts[0].substr(-3,dataParts[0].length).toUpperCase()
-      talker = dataParts[0].substr(1,2).toUpperCase()
-      internalId = dataParts[0].substr(1,dataParts[0].length)
+    let id = ''
+    let talker = ''
+    let internalId = ''
+
+    if (dataParts[0].charAt(1).toUpperCase() === 'P') { // proprietary sentence
+      id = dataParts[0].substr(-3, dataParts[0].length).toUpperCase()
+      talker = dataParts[0].substr(1, 2).toUpperCase()
+      internalId = dataParts[0].substr(1, dataParts[0].length)
     } else {
       id = dataParts[0].substr(3, 3).toUpperCase()
       talker = dataParts[0].substr(1, 2)
@@ -87,8 +92,7 @@ class Parser {
         tags
       }, this.session)
       return transformSource(result, id, talker)
-    }
-    else {
+    } else {
       return null
     }
   }

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
   "bugs": {
     "url": "https://github.com/signalk/signalk-parser-nmea0183/issues"
   },
-  "homepage": "https://github.com/signalk/signalk-parser-nmea0183"
+  "homepage": "https://github.com/signalk/signalk-parser-nmea0183",
+  "standard": {
+    "globals": ["describe", "it"]
+  }
 }

--- a/test/APB.js
+++ b/test/APB.js
@@ -18,18 +18,37 @@
 
 const Parser = require('../lib')
 const chai = require('chai')
-const should = require('chai').Should()
+const should = chai.Should()
 
 chai.Should()
 chai.use(require('chai-things'))
 
 describe('APB', done => {
-  it('Doesn\'t parse APB sentences', () => {
-    should.Throw(() => {
-      new Parser().parse('$GPAPB,A,A,0.10,R,N,V,V,011,M,DEST,011,M,011,M*3C')
-      },
-      /@FIXME: APB hook needs to be rewritten to fit latest version of SK/
-    )
+  it('Converts OK using individual parser', () => {
+    const delta = new Parser().parse('$GPAPB,A,A,0.10,R,N,V,V,011,M,DEST,011,M,011,M*3C')
+    // console.log(JSON.stringify(delta, null, 2))
+
+    delta.should.be.an('object')
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'navigation.courseRhumbline.crossTrackError')
+    delta.updates[0].values.should.contain.an.item.with.property('value', -0.1)
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'navigation.courseRhumbline.bearingTrackMagnetic')
+    delta.updates[0].values.should.contain.an.item.with.property('value', 0.19198621776321237)
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'navigation.courseRhumbline.bearingOriginToDestinationMagnetic')
+    delta.updates[0].values.should.contain.an.item.with.property('value', 0.19198621776321237)
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'navigation.courseRhumbline.bearingToDestinationMagnetic')
+    delta.updates[0].values.should.contain.an.item.with.property('value', 0.19198621776321237)
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'navigation.courseRhumbline.nextPoint.ID')
+    delta.updates[0].values.should.contain.an.item.with.property('value', 'DEST')
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'steering.autopilot.target.headingMagnetic')
+    delta.updates[0].values.should.contain.an.item.with.property('value', 0.19198621776321237)
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'notifications.arrivalCircleEntered')
+    delta.updates[0].values.should.contain.an.item.with.property('value', null)
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'notifications.perpendicularPassed')
+    delta.updates[0].values.should.contain.an.item.with.property('value', null)
   })
 
+  it('Doesn\'t choke on an empty sentence', () => {
+    const delta = new Parser().parse('$GPAPB,,,,,,,,,,,,,,*44')
+    should.equal(delta, null)
+  })
 })

--- a/test/BOD.js
+++ b/test/BOD.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2016 Signal K and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict'
+
+const Parser = require('../lib')
+const chai = require('chai')
+const should = chai.Should()
+
+chai.Should()
+chai.use(require('chai-things'))
+
+describe('BOD', () => {
+  it('Converts OK using individual parser', () => {
+    const delta = new Parser().parse('$GPBOD,045.,T,023.,M,DEST,START*01')
+    // console.log(JSON.stringify(delta, null, 2))
+
+    delta.should.be.an('object')
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'navigation.courseRhumbline.bearingTrackTrue')
+    delta.updates[0].values.should.contain.an.item.with.property('value', 0.7853981635767779)
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'navigation.courseRhumbline.bearingTrackMagnetic')
+    delta.updates[0].values.should.contain.an.item.with.property('value', 0.40142572805035315)
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'navigation.courseRhumbline.nextPoint.ID')
+    delta.updates[0].values.should.contain.an.item.with.property('value', 'DEST')
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'navigation.courseRhumbline.previousPoint.ID')
+    delta.updates[0].values.should.contain.an.item.with.property('value', 'START')
+  })
+
+  it('Doesn\'t choke on an empty sentence', () => {
+    const delta = new Parser().parse('$GPBOD,,,,,,*5E')
+    should.equal(delta, null)
+  })
+})

--- a/test/BWC.js
+++ b/test/BWC.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2016 Signal K and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict'
+
+const Parser = require('../lib')
+const chai = require('chai')
+const should = chai.Should()
+
+chai.Should()
+chai.use(require('chai-things'))
+
+describe('BWC', () => {
+  it('Converts OK using individual parser', () => {
+    const delta = new Parser().parse('$GPBWC,225444,4917.24,N,12309.57,W,051.9,T,031.6,M,001.3,N,004*29')
+    // console.log(JSON.stringify(delta, null, 2))
+
+    delta.should.be.an('object')
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'navigation.courseGreatCircle.bearingTrackTrue')
+    delta.updates[0].values.should.contain.an.item.with.property('value', 0.9058258819918839)
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'navigation.courseGreatCircle.bearingTrackMagnetic')
+    delta.updates[0].values.should.contain.an.item.with.property('value', 0.5515240437561374)
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'navigation.courseGreatCircle.nextPoint.distance')
+    delta.updates[0].values.should.contain.an.item.with.property('value', 1.3)
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'navigation.courseGreatCircle.nextPoint.position')
+  })
+
+  it('Doesn\'t choke on an empty sentence', () => {
+    const delta = new Parser().parse('$GPBWC,,,,,,,,,,,,*41')
+    should.equal(delta, null)
+  })
+})

--- a/test/BWR.js
+++ b/test/BWR.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2016 Signal K and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict'
+
+const Parser = require('../lib')
+const chai = require('chai')
+const should = chai.Should()
+
+chai.Should()
+chai.use(require('chai-things'))
+
+describe('BWR', () => {
+  it('Converts OK using individual parser', () => {
+    const delta = new Parser().parse('$GPBWR,225444,4917.24,N,12309.57,W,051.9,T,031.6,M,001.3,N,004*38')
+    // console.log(JSON.stringify(delta, null, 2))
+
+    delta.should.be.an('object')
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'navigation.courseRhumbline.bearingTrackTrue')
+    delta.updates[0].values.should.contain.an.item.with.property('value', 0.9058258819918839)
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'navigation.courseRhumbline.bearingTrackMagnetic')
+    delta.updates[0].values.should.contain.an.item.with.property('value', 0.5515240437561374)
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'navigation.courseRhumbline.nextPoint.distance')
+    delta.updates[0].values.should.contain.an.item.with.property('value', 1.3)
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'navigation.courseRhumbline.nextPoint.position')
+  })
+
+  it('Doesn\'t choke on an empty sentence', () => {
+    const delta = new Parser().parse('$GPBWR,,,,,,,,,,,,*50')
+    should.equal(delta, null)
+  })
+})

--- a/test/HSC.js
+++ b/test/HSC.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2016 Signal K and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict'
+
+const Parser = require('../lib')
+const chai = require('chai')
+const should = chai.Should()
+
+chai.Should()
+chai.use(require('chai-things'))
+
+describe('HSC', () => {
+  it('Converts OK using individual parser', () => {
+    const delta = new Parser().parse('$FTHSC,40.12,T,39.11,M*5E')
+    // console.log(JSON.stringify(delta, null, 2))
+
+    delta.should.be.an('object')
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'steering.autopilot.target.headingTrue')
+    delta.updates[0].values.should.contain.an.item.with.property('value', 0.7002260960600073)
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'steering.autopilot.target.headingMagnetic')
+    delta.updates[0].values.should.contain.an.item.with.property('value', 0.6825982706108397)
+  })
+
+  it('Doesn\'t choke on an empty sentence', () => {
+    const delta = new Parser().parse('$FTHSC,,,,*4A')
+    should.equal(delta, null)
+  })
+})

--- a/test/XTE.js
+++ b/test/XTE.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2016 Signal K and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict'
+
+const Parser = require('../lib')
+const chai = require('chai')
+const should = chai.Should()
+
+chai.Should()
+chai.use(require('chai-things'))
+
+describe('XTE', () => {
+  it('Converts OK using individual parser', () => {
+    const delta = new Parser().parse('$GPXTE,A,A,0.67,L,N*6F')
+    // console.log(JSON.stringify(delta, null, 2))
+
+    delta.should.be.an('object')
+    delta.updates[0].values.should.contain.an.item.with.property('path', 'navigation.courseRhumbline.crossTrackError')
+    delta.updates[0].values.should.contain.an.item.with.property('value', 0.67)
+  })
+
+  it('Doesn\'t choke on an empty sentence', () => {
+    const delta = new Parser().parse('$GPXTE,,,,,*72')
+    should.equal(delta, null)
+  })
+})


### PR DESCRIPTION
This PR implements hooks & tests for the following NMEA0183 sentences:

1. ABP - Autopilot sentence "B"*
2. BOD - Bearing origin to destination waypoint
3. BWC - Bearing and distance to waypoint - great circle
4. BWR - Bearing and distance to waypoint - rhumb line
5. HSC - Heading steering command
6. XTE - Cross-track error

_* There used to be a hook for APB, but it had been deprecated in the past due to spec changes_