### PR TITLE
feature: add information needed to detect bluesign

### DIFF
--- a/hooks/VDM.js
+++ b/hooks/VDM.js
@@ -59,6 +59,13 @@ const msgTypeToPrefix = {
   24: "vessels."
 }
 
+const specialManeuverMapping = {
+  0: 'not available',
+  1: 'not engaged',
+  2: 'engaged',
+  3: 'reserved'
+}
+
 module.exports = function (input, session) {
   const { id, sentence, parts, tags } = input
   const data = new Decoder(sentence, session)
@@ -216,6 +223,27 @@ module.exports = function (input, session) {
         value: { "id": data.cargo, "name": typeName }
       })
     }
+  }
+
+  if ( typeof data.smi !== 'undefined' ) {
+    values.push({
+      path: 'navigation.specialManeuver',
+      value: specialManeuverMapping[data.smi]
+    })
+  }
+
+  if ( typeof data.dac !== 'undefined' ) {
+    values.push({
+      path: 'sensors.ais.designatedAreaCode',
+      value: data.dac
+    })
+  }
+
+  if ( typeof data.fid !== 'undefined' ) {
+    values.push({
+      path: 'sensors.ais.functionalId',
+      value: data.fid
+    })
   }
 
   if (values.length === 0) {

--- a/test/VDM.js
+++ b/test/VDM.js
@@ -97,5 +97,22 @@ describe('VDM', function() {
     const delta = new Parser().parse('!AIVDM,1,1,,B,13aGra0P00PHid>NK9<2FOvHR624,0*3E\n')
     delta.updates[0].values.find(pathValue => pathValue.path === 'navigation.state').value.should.equal('motoring')
     delta.updates[0].values.find(pathValue => pathValue.path === 'sensors.ais.class').value.should.equal('A')
+  })
+
+  it('class A position report with specialManeuver converts ok', () => {
+    const delta = new Parser().parse('!AIVDM,1,1,,B,13aGra0P00PHid>NK9<2FOvHR624,0*3E\n')
+    delta.updates[0].values.find(pathValue => pathValue.path === 'navigation.specialManeuver').value.should.equal('not engaged')
+  })
+
+  it('class A position report with specialManeuver converts ok', () => {
+    const delta = new Parser().parse('!AIVDM,1,1,,B,13aGra0P00PHid>NK9<2FOvHR624,0*3E\n')
+    delta.updates[0].values.find(pathValue => pathValue.path === 'navigation.specialManeuver').value.should.equal('not engaged')
+  })
+
+  it('msg type 8 converts ok', () => {
+    const delta = new Parser().parse('!AIVDM,1,1,,A,85Mv070j2d>=<e<<=PQhhg`59P00,0*26')
+    delta.context.should.equal('vessels.urn:mrn:imo:mmsi:366968860')
+    delta.updates[0].values.find(pathValue => pathValue.path === 'sensors.ais.designatedAreaCode').value.should.equal(200)
+    delta.updates[0].values.find(pathValue => pathValue.path === 'sensors.ais.functionalId').value.should.equal(10)
    })
 })


### PR DESCRIPTION

smi is under the path `navigation.specialManeuver` and can be `not available`, `not engaged`, `engaged` or `reserved`

`sensors.ais.designatedAreaCode` and `sensors.ais.functionalId` are integers

Closes #165 